### PR TITLE
Fix copyright and retval docs

### DIFF
--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -2,7 +2,7 @@
  * @file ITC_Event.c
  * @brief Implementation of the Interval Tree Clock's Event mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -28,8 +28,8 @@
  *
  * @param pt_Event The Event to validate
  * @param b_CheckIsNormalised Whether to check if the Event is normalised
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t validateEvent(
     const ITC_Event_t *pt_Event,
@@ -123,8 +123,8 @@ static ITC_Status_t validateEvent(
  * @param ppt_Parent The pointer to the parent Event in the tree.
  * Otherwise NULL.
  * @param t_Count The number of events witnessed by the Event
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t newEvent(
     ITC_Event_t **ppt_Event,
@@ -165,8 +165,8 @@ static ITC_Status_t newEvent(
  * @param pt_Event The existing Event
  * @param ppt_ClonedEvent The pointer to the cloned Event
  * @param pt_ParentEvent The pointer to parent Event. Otherwise NULL
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t cloneEvent(
     const ITC_Event_t *pt_Event,
@@ -261,8 +261,8 @@ static ITC_Status_t cloneEvent(
  *
  * @param pt_Counter The counter to increment
  * @param t_IncCount The amount to increment with
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t incEventCounter(
     ITC_Event_Counter_t *pt_Counter,
@@ -298,8 +298,8 @@ static ITC_Status_t incEventCounter(
  *
  * @param pt_Counter The counter to decrement
  * @param t_DecCount The amount to decrement with
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t decEventCounter(
     ITC_Event_Counter_t *pt_Counter,
@@ -334,8 +334,8 @@ static ITC_Status_t decEventCounter(
  * equal to 0
  *
  * @param pt_Event The Event on which to perform the operation
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t liftSinkSinkEvent(
     ITC_Event_t *pt_Event
@@ -403,8 +403,8 @@ static ITC_Status_t liftSinkSinkEvent(
  *
  * @param pt_Event The Event on which to perform the operation
  * children
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t liftDestroyDestroyEvent(
     ITC_Event_t *pt_Event
@@ -487,8 +487,8 @@ static ITC_Status_t liftDestroyDestroyEvent(
  * children
  * @param t_LeftCount The event counter to assign to the left child node
  * @param t_RightCount The event counter to assign to the right child node
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t createChildEventNodes(
     ITC_Event_t *pt_Event,
@@ -534,8 +534,8 @@ static ITC_Status_t createChildEventNodes(
  *      - min((n, e1, e2)) = n
  *
  * @param pt_Event The Event to normalise
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t normEventE(
     ITC_Event_t *pt_Event
@@ -625,8 +625,8 @@ static ITC_Status_t normEventE(
  * @param pt_Event1 The first Event
  * @param pt_Event2 The second Event
  * @param ppt_Event The new Event
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t joinEventE(
     const ITC_Event_t *const pt_Event1,
@@ -835,8 +835,8 @@ static ITC_Status_t joinEventE(
  * @param pt_Event1 The first Event
  * @param pt_Event2 The second Event
  * @param pb_IsLeq (out) `true` if `*pt_Event1 <= *pt_Event2`. Otherwise `false`
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t leqEventE(
     const ITC_Event_t *pt_Event1,
@@ -1014,8 +1014,8 @@ static ITC_Status_t leqEventE(
  * The resulting Event is always a leaf Event
  *
  * @param pt_Event The Event to maximise
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t maxEventE(
     ITC_Event_t *pt_Event
@@ -1072,8 +1072,8 @@ static ITC_Status_t maxEventE(
  * @param pt_Id The ID showing the ownership information for the interval
  * @param pb_WasFilled (out) Whether the event was filled or not. In some cases
  * filling an Event (simplifying + inflating) is not possible
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t fillEventE(
     ITC_Event_t *pt_Event,
@@ -1301,8 +1301,8 @@ static ITC_Status_t fillEventE(
  *
  * @param pt_Event The Event to grow
  * @param pt_Id The ID showing the ownership information for the interval
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t growEventE(
     ITC_Event_t *pt_Event,

--- a/libitc/ITC_Event_private.h
+++ b/libitc/ITC_Event_private.h
@@ -2,7 +2,7 @@
  * @file ITC_Event_private.h
  * @brief Private definitions for the Interval Tree Clock's Event mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -2,7 +2,7 @@
  * @file ITC_Id.c
  * @brief Implementation of the Interval Tree Clock's ID mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -26,8 +26,8 @@
  *
  * @param pt_Id The ID to validate
  * @param b_CheckIsNormalised Whether to check if the ID is normalised
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t validateId(
     const ITC_Id_t *pt_Id,
@@ -117,8 +117,8 @@ static ITC_Status_t validateId(
  * @param ppt_Id (out) The pointer to the new ID
  * @param ppt_Parent The pointer to the parent ID in the tree. Otherwise NULL.
  * @param b_IsOwner Whether the ID owns its interval or not.
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t newId(
     ITC_Id_t **ppt_Id,
@@ -159,8 +159,8 @@ static ITC_Status_t newId(
  * @param pt_Id The existing ID
  * @param ppt_ClonedId The pointer to the cloned ID
  * @param pt_ParentId The pointer to parent ID. Otherwise NULL
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t cloneId(
     const ITC_Id_t *pt_Id,
@@ -342,8 +342,8 @@ static ITC_Status_t splitId1(
  * @param pt_Id The existing ID
  * @param ppt_Id1 The first ID
  * @param ppt_Id2 The second ID
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t splitIdI(
     const ITC_Id_t *pt_Id,
@@ -577,8 +577,8 @@ static ITC_Status_t splitIdI(
  *
  * @param pt_Id The ID on which to perform the operation
  * children
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t normId11Or00(
     ITC_Id_t *pt_Id
@@ -635,8 +635,8 @@ static ITC_Status_t normId11Or00(
  *  - norm(i) = i
  *
  * @param pt_Id The ID to normalise
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t normIdI(
     ITC_Id_t *pt_Id
@@ -725,8 +725,8 @@ static ITC_Status_t normIdI(
  * @param pt_Id1 The first ID
  * @param pt_Id2 The second ID
  * @param ppt_Id The new ID
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t sumIdI(
     const ITC_Id_t *pt_Id1,

--- a/libitc/ITC_Id_private.h
+++ b/libitc/ITC_Id_private.h
@@ -2,7 +2,7 @@
  * @file ITC_Id_private.h
  * @brief Private definitions for the Interval Tree Clock's ID mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/ITC_Port.c
+++ b/libitc/ITC_Port.c
@@ -2,7 +2,7 @@
  * @file ITC_Port.c
  * @brief Port specific implementation
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/ITC_Stamp.c
+++ b/libitc/ITC_Stamp.c
@@ -2,7 +2,7 @@
  * @file ITC_Stamp.c
  * @brief Implementation of the Interval Tree Clock's Stamp mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/ITC_Stamp.c
+++ b/libitc/ITC_Stamp.c
@@ -25,8 +25,8 @@
  * Should be used to validate all incoming Stamps before any processing is done.
  *
  * @param pt_Stamp The Stamp to validate
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t validateStamp(
     const ITC_Stamp_t *const pt_Stamp
@@ -66,8 +66,8 @@ static ITC_Status_t validateStamp(
  * Stamp. Ignored if pt_Id == NULL
  * @param b_CloneEvent Whether to clone or simply assign the passed Event to the
  * Stamp. Ignored if pt_Event == NULL
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t newStamp(
     ITC_Stamp_t **ppt_Stamp,
@@ -175,8 +175,8 @@ static ITC_Status_t newStamp(
  * @param pt_Stamp1 The first Stamp
  * @param pt_Stamp2 The second Stamp
  * @param pt_Result The result of the comparison
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 static ITC_Status_t compareStamps(
     const ITC_Stamp_t *const pt_Stamp1,

--- a/libitc/include/ITC.h
+++ b/libitc/include/ITC.h
@@ -2,7 +2,7 @@
  * @file ITC.h
  * @brief The Interval Tree Clocks (ITC) library
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/include/ITC_Event.h
+++ b/libitc/include/ITC_Event.h
@@ -2,7 +2,7 @@
  * @file ITC_Event.h
  * @brief Definitions for the Interval Tree Clock's Event mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/include/ITC_Id.h
+++ b/libitc/include/ITC_Id.h
@@ -2,7 +2,7 @@
  * @file ITC_Id.h
  * @brief Definitions for the Interval Tree Clock's ID mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/include/ITC_Port.h
+++ b/libitc/include/ITC_Port.h
@@ -2,7 +2,7 @@
  * @file ITC_port.h
  * @brief Port specific definitions
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/include/ITC_Port.h
+++ b/libitc/include/ITC_Port.h
@@ -19,8 +19,8 @@
  *
  * @param ppv_Ptr (out) Pointer to the allocated memory
  * @param n_Size The size to allocate
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Port_malloc(
     void **ppv_Ptr,
@@ -31,8 +31,8 @@ ITC_Status_t ITC_Port_malloc(
  * @brief Deallocate memory
  *
  * @param pv_Ptr Pointer to the memory to be freed
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Port_free(
     void *pv_Ptr

--- a/libitc/include/ITC_Stamp.h
+++ b/libitc/include/ITC_Stamp.h
@@ -2,7 +2,7 @@
  * @file ITC_Stamp.h
  * @brief Definitions for the Interval Tree Clock's Stamp mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/include/ITC_Stamp_prototypes.h
+++ b/libitc/include/ITC_Stamp_prototypes.h
@@ -21,8 +21,8 @@
  * @brief Allocate a new ITC seed Stamp and initialise it
  *
  * @param ppt_Stamp (out) The pointer to the Stamp
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_newSeed(
     ITC_Stamp_t **ppt_Stamp
@@ -33,8 +33,8 @@ ITC_Status_t ITC_Stamp_newSeed(
  *
  * @param pt_Stamp The existing Stamp
  * @param ppt_PeekStamp (out) The pointer to the peek Stamp
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_newPeek(
     const ITC_Stamp_t *const pt_Stamp,
@@ -49,8 +49,8 @@ ITC_Status_t ITC_Stamp_newPeek(
  * be set to `NULL`.
  *
  * @param ppt_Stamp (in) The pointer to the Stamp to deallocate. (out) NULL
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_destroy(
     ITC_Stamp_t **ppt_Stamp
@@ -61,8 +61,8 @@ ITC_Status_t ITC_Stamp_destroy(
  *
  * @param pt_Stamp The existing Stamp
  * @param ppt_ClonedStamp (out) The pointer to the cloned Stamp
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_clone(
     const ITC_Stamp_t *const pt_Stamp,
@@ -77,8 +77,8 @@ ITC_Status_t ITC_Stamp_clone(
  * @param pt_Stamp The existing Stamp
  * @param ppt_Stamp1 (out) The first Stamp
  * @param ppt_Stamp2 (out) The second Stamp
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_fork(
     const ITC_Stamp_t *const pt_Stamp,
@@ -93,8 +93,8 @@ ITC_Status_t ITC_Stamp_fork(
  * updated state and should not be used further.
  *
  * @param pt_Stamp The existing Stamp
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_event(
     const ITC_Stamp_t *const pt_Stamp
@@ -107,8 +107,8 @@ ITC_Status_t ITC_Stamp_event(
  * @param pt_Stamp1 The first Stamp
  * @param pt_Stamp2 The second Stamp
  * @param ppt_Stamp (out) The pointer to the joined Stamp
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_join(
     const ITC_Stamp_t *const pt_Stamp1,
@@ -131,8 +131,8 @@ ITC_Status_t ITC_Stamp_join(
  * @param pt_Stamp1 The first Stamp
  * @param pt_Stamp2 The second Stamp
  * @param pt_Result (out) The result of the comparison
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_compare(
     const ITC_Stamp_t *const pt_Stamp1,

--- a/libitc/include/ITC_Stamp_prototypes.h
+++ b/libitc/include/ITC_Stamp_prototypes.h
@@ -2,7 +2,7 @@
  * @file ITC_Stamp_prototypes.h
  * @brief Prototypes for the Interval Tree Clock's Stamp mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/include/ITC_Status.h
+++ b/libitc/include/ITC_Status.h
@@ -2,7 +2,7 @@
  * @file ITC_Status.h
  * @brief Status codes for the ITC implementation
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/include/ITC_config.h
+++ b/libitc/include/ITC_config.h
@@ -2,7 +2,7 @@
  * @file ITC_config.h
  * @brief Configuration options for the ITC implementation
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/package-include/ITC_Event_package.h
+++ b/libitc/package-include/ITC_Event_package.h
@@ -2,7 +2,7 @@
  * @file ITC_Event_package.h
  * @brief Package definitions for the Interval Tree Clock's Event mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/package-include/ITC_Event_package.h
+++ b/libitc/package-include/ITC_Event_package.h
@@ -25,8 +25,8 @@
  * @brief Allocate a new ITC Event and initialise it
  *
  * @param ppt_Event (out) The pointer to the Event
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_new(
     ITC_Event_t **ppt_Event
@@ -40,8 +40,8 @@ ITC_Status_t ITC_Event_new(
  * be set to `NULL`.
  *
  * @param ppt_Event (in) The pointer to the Event to deallocate. (out) NULL
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_destroy(
     ITC_Event_t **ppt_Event
@@ -52,8 +52,8 @@ ITC_Status_t ITC_Event_destroy(
  *
  * @param pt_Event The existing Event
  * @param ppt_ClonedEvent (out) The pointer to the cloned Event
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_clone(
     const ITC_Event_t *const pt_Event,
@@ -64,8 +64,8 @@ ITC_Status_t ITC_Event_clone(
  * @brief Validate an Event
  *
  * @param pt_Event The Event to validate
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_validate(
     const ITC_Event_t *const pt_Event
@@ -75,8 +75,8 @@ ITC_Status_t ITC_Event_validate(
  * @brief Normalise an Event
  *
  * @param pt_Event The Event to normalise
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_normalise(
     ITC_Event_t *pt_Event
@@ -89,8 +89,8 @@ ITC_Status_t ITC_Event_normalise(
  * the largest total sum of events in the tree.
  *
  * @param pt_Event The Event to maximise
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_maximise(
     ITC_Event_t *pt_Event
@@ -102,8 +102,8 @@ ITC_Status_t ITC_Event_maximise(
  * @param pt_Event1 The first Event
  * @param pt_Event2 The second Event
  * @param ppt_Event (out) The pointer to the joined Event
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_join(
     const ITC_Event_t *const pt_Event1,
@@ -117,8 +117,8 @@ ITC_Status_t ITC_Event_join(
  * @param pt_Event1 The first Event
  * @param pt_Event2 The second Event
  * @param pb_IsLeq (out) `true` if `*pt_Event1 <= *pt_Event2`. Otherwise `false`
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_leq(
     const ITC_Event_t *const pt_Event1,
@@ -137,8 +137,8 @@ ITC_Status_t ITC_Event_leq(
  * @param pt_Event The Event to fill
  * @param pt_Id The ID showing the ownership information for the interval
  * @param pb_WasFilled Whether filling the Event was successful or not
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_fill(
     ITC_Event_t *pt_Event,
@@ -160,8 +160,8 @@ ITC_Status_t ITC_Event_fill(
  *
  * @param pt_Event The Event to fill
  * @param pt_Id The ID showing the ownership information for the interval
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_grow(
     ITC_Event_t *pt_Event,

--- a/libitc/package-include/ITC_Id_package.h
+++ b/libitc/package-include/ITC_Id_package.h
@@ -2,7 +2,7 @@
  * @file ITC_Id_package.h
  * @brief Prototypes for the Interval Tree Clock's ID mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/package-include/ITC_Id_package.h
+++ b/libitc/package-include/ITC_Id_package.h
@@ -21,8 +21,8 @@
  * @brief Allocate a new ITC ID and initialise it as a seed ID (1)
  *
  * @param ppt_Id (out) The pointer to the seed ID
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_newSeed(
     ITC_Id_t **ppt_Id
@@ -32,8 +32,8 @@ ITC_Status_t ITC_Id_newSeed(
  * @brief Allocate a new ITC ID and initialise it as a null ID (0)
  *
  * @param ppt_Id (out) The pointer to the null ID
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_newNull(
     ITC_Id_t **ppt_Id
@@ -47,8 +47,8 @@ ITC_Status_t ITC_Id_newNull(
  * set to `NULL`.
  *
  * @param ppt_Id (in) The pointer to the ID to deallocate. (out) NULL
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_destroy(
     ITC_Id_t **ppt_Id
@@ -61,8 +61,8 @@ ITC_Status_t ITC_Id_destroy(
  * On error, the cloned ID is automatically deallocated.
  * @param pt_Id The existing ID
  * @param ppt_ClonedId (out) The pointer to the cloned ID
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_clone(
     const ITC_Id_t *const pt_Id,
@@ -73,8 +73,8 @@ ITC_Status_t ITC_Id_clone(
  * @brief Validate an ID
  *
  * @param pt_Id The ID to validate
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_validate(
     const ITC_Id_t *const pt_Id
@@ -86,8 +86,8 @@ ITC_Status_t ITC_Id_validate(
  * @param pt_Id The existing ID
  * @param ppt_Id1 (out) The pointer to the first split ID
  * @param ppt_Id2 (out) The pointer to the second split  ID
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_split(
     const ITC_Id_t *const pt_Id,
@@ -99,8 +99,8 @@ ITC_Status_t ITC_Id_split(
  * @brief Normalise an ID
  *
  * @param pt_Id The ID to normalise
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_normalise(
     ITC_Id_t *pt_Id
@@ -112,8 +112,8 @@ ITC_Status_t ITC_Id_normalise(
  * @param pt_Id1 The first ID
  * @param pt_Id2 The second ID
  * @param ppt_Id (out) The pointer to the summed ID
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_sum(
     const ITC_Id_t *const pt_Id1,

--- a/libitc/test/ITC_TestUtil.c
+++ b/libitc/test/ITC_TestUtil.c
@@ -2,7 +2,7 @@
  * @file ITC_TestUtil.h
  * @brief Testing utilities
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/test/include/ITC_Event_Test_package.h
+++ b/libitc/test/include/ITC_Event_Test_package.h
@@ -2,7 +2,7 @@
  * @file ITC_Event_Test_package.h
  * @brief Package testing definitions for Interval Tree Clock's Event mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/test/include/ITC_Id_Test_package.h
+++ b/libitc/test/include/ITC_Id_Test_package.h
@@ -2,7 +2,7 @@
  * @file ITC_Id_Test_package.h
  * @brief Package testing definitions for Interval Tree Clock's ID mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/test/include/ITC_TestUtil.h
+++ b/libitc/test/include/ITC_TestUtil.h
@@ -2,7 +2,7 @@
  * @file ITC_TestUtil.h
  * @brief Testing utilities
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/test/include/ITC_TestUtil.h
+++ b/libitc/test/include/ITC_TestUtil.h
@@ -93,8 +93,8 @@ extern const uint32_t gu32_InvalidEventTablesSize;
  *
  * @param ppt_Id (out) The pointer to the NULL ID
  * @param pt_Parent The pointer to the parent ID. Otherwise NULL
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_TestUtil_newNullId(
     ITC_Id_t **ppt_Id,
@@ -106,8 +106,8 @@ ITC_Status_t ITC_TestUtil_newNullId(
  *
  * @param ppt_Id (out) The pointer to the seed ID
  * @param pt_Parent The pointer to the parent ID. Otherwise NULL
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_TestUtil_newSeedId(
     ITC_Id_t **ppt_Id,
@@ -120,8 +120,8 @@ ITC_Status_t ITC_TestUtil_newSeedId(
  *
  * @param ppt_Event (out) The pointer to the Event
  * @param pt_Parent The pointer to the parent Event. Otherwise NULL
- * @return ITC_Status_t The status of the operation
- * @retval ITC_STATUS_SUCCESS on success
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_TestUtil_newEvent(
     ITC_Event_t **ppt_Event,

--- a/libitc/test/include/ITC_Test_package.h
+++ b/libitc/test/include/ITC_Test_package.h
@@ -2,7 +2,7 @@
  * @file ITC_Test_package.h
  * @brief Unit testing package definitions
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/test/mocked/ITC_Event_Test.c
+++ b/libitc/test/mocked/ITC_Event_Test.c
@@ -2,7 +2,7 @@
  * @file ITC_Event_Test.h
  * @brief Unit tests for the Interval Tree Clock's Event mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/test/mocked/ITC_Id_Test.c
+++ b/libitc/test/mocked/ITC_Id_Test.c
@@ -2,7 +2,7 @@
  * @file ITC_Id_Test.h
  * @brief Unit tests for the Interval Tree Clock's ID mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/test/normal/ITC_Event_Test.c
+++ b/libitc/test/normal/ITC_Event_Test.c
@@ -2,7 +2,7 @@
  * @file ITC_Event_Test.h
  * @brief Unit tests for the Interval Tree Clock's Event mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/test/normal/ITC_Id_Test.c
+++ b/libitc/test/normal/ITC_Id_Test.c
@@ -2,7 +2,7 @@
  * @file ITC_Id_Test.h
  * @brief Unit tests for the Interval Tree Clock's ID mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *

--- a/libitc/test/normal/ITC_Stamp_Test.c
+++ b/libitc/test/normal/ITC_Stamp_Test.c
@@ -2,7 +2,7 @@
  * @file ITC_Stamp_Test.h
  * @brief Unit tests for the Interval Tree Clock's Stamp mechanism
  *
- * @copyright Copyright (c) 2024 libITC project. Released under AGPL-3.0
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
  * license. Refer to the LICENSE file for details or visit:
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *


### PR DESCRIPTION
Fixes project name in copyrght banners and adds backticks to types in retval docs for better readability.