### PR TITLE
Disable unneeded package API when not building unit tests

### DIFF
--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -2044,46 +2044,6 @@ ITC_Status_t ITC_Event_validate(
 }
 
 /******************************************************************************
- * Normalise an Event
- ******************************************************************************/
-
-ITC_Status_t ITC_Event_normalise(
-    ITC_Event_t *pt_Event
-)
-{
-    ITC_Status_t t_Status; /* The current status */
-
-    t_Status = validateEvent(pt_Event, false);
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        t_Status = normEventE(pt_Event);
-    }
-
-    return t_Status;
-}
-
-/******************************************************************************
- * Maximise an Event
- ******************************************************************************/
-
-ITC_Status_t ITC_Event_maximise(
-    ITC_Event_t *pt_Event
-)
-{
-    ITC_Status_t t_Status; /* The current status */
-
-    t_Status = validateEvent(pt_Event, true);
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        t_Status = maxEventE(pt_Event);
-    }
-
-    return t_Status;
-}
-
-/******************************************************************************
  * Join two existing Events into a single Event
  ******************************************************************************/
 
@@ -2326,3 +2286,47 @@ ITC_Status_t ITC_SerDes_deserialiseEvent(
 }
 
 #endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
+
+#if IS_UNIT_TEST_BUILD
+
+/******************************************************************************
+ * Normalise an Event
+ ******************************************************************************/
+
+ITC_Status_t ITC_Event_normalise(
+    ITC_Event_t *pt_Event
+)
+{
+    ITC_Status_t t_Status; /* The current status */
+
+    t_Status = validateEvent(pt_Event, false);
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        t_Status = normEventE(pt_Event);
+    }
+
+    return t_Status;
+}
+
+/******************************************************************************
+ * Maximise an Event
+ ******************************************************************************/
+
+ITC_Status_t ITC_Event_maximise(
+    ITC_Event_t *pt_Event
+)
+{
+    ITC_Status_t t_Status; /* The current status */
+
+    t_Status = validateEvent(pt_Event, true);
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        t_Status = maxEventE(pt_Event);
+    }
+
+    return t_Status;
+}
+
+#endif /* IS_UNIT_TEST_BUILD */

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -1356,26 +1356,6 @@ ITC_Status_t ITC_Id_sum(
 }
 
 /******************************************************************************
- * Normalise an ID
- ******************************************************************************/
-
-ITC_Status_t ITC_Id_normalise(
-    ITC_Id_t *pt_Id
-)
-{
-    ITC_Status_t t_Status; /* The current status */
-
-    t_Status = validateId(pt_Id, false);
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        t_Status = normIdI(pt_Id);
-    }
-
-    return t_Status;
-}
-
-/******************************************************************************
  * Serialise an existing ITC Id
  ******************************************************************************/
 
@@ -1483,3 +1463,27 @@ ITC_Status_t ITC_SerDes_deserialiseId(
 }
 
 #endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
+
+#if IS_UNIT_TEST_BUILD
+
+/******************************************************************************
+ * Normalise an ID
+ ******************************************************************************/
+
+ITC_Status_t ITC_Id_normalise(
+    ITC_Id_t *pt_Id
+)
+{
+    ITC_Status_t t_Status; /* The current status */
+
+    t_Status = validateId(pt_Id, false);
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        t_Status = normIdI(pt_Id);
+    }
+
+    return t_Status;
+}
+
+#endif /* IS_UNIT_TEST_BUILD */

--- a/libitc/package-include/ITC_Event_package.h
+++ b/libitc/package-include/ITC_Event_package.h
@@ -77,31 +77,6 @@ ITC_Status_t ITC_Event_validate(
 #endif /* !ITC_CONFIG_ENABLE_EXTENDED_API */
 
 /**
- * @brief Normalise an Event
- *
- * @param pt_Event The Event to normalise
- * @return `ITC_Status_t` The status of the operation
- * @retval `ITC_STATUS_SUCCESS` on success
- */
-ITC_Status_t ITC_Event_normalise(
-    ITC_Event_t *pt_Event
-);
-
-/**
- * @brief Maximise an Event
- *
- * Transforms any Event tree into a leaf Event with an event counter equal to
- * the largest total sum of events in the tree.
- *
- * @param pt_Event The Event to maximise
- * @return `ITC_Status_t` The status of the operation
- * @retval `ITC_STATUS_SUCCESS` on success
- */
-ITC_Status_t ITC_Event_maximise(
-    ITC_Event_t *pt_Event
-);
-
-/**
  * @brief Join two existing Events into a single Event
  *
  * @param pt_Event1 The first Event
@@ -172,5 +147,34 @@ ITC_Status_t ITC_Event_grow(
     ITC_Event_t *pt_Event,
     const ITC_Id_t *const pt_Id
 );
+
+#if IS_UNIT_TEST_BUILD
+
+/**
+ * @brief Normalise an Event
+ *
+ * @param pt_Event The Event to normalise
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
+ */
+ITC_Status_t ITC_Event_normalise(
+    ITC_Event_t *pt_Event
+);
+
+/**
+ * @brief Maximise an Event
+ *
+ * Transforms any Event tree into a leaf Event with an event counter equal to
+ * the largest total sum of events in the tree.
+ *
+ * @param pt_Event The Event to maximise
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
+ */
+ITC_Status_t ITC_Event_maximise(
+    ITC_Event_t *pt_Event
+);
+
+#endif /* IS_UNIT_TEST_BUILD */
 
 #endif /* ITC_EVENT_PACKAGE_H_ */

--- a/libitc/package-include/ITC_Id_package.h
+++ b/libitc/package-include/ITC_Id_package.h
@@ -115,6 +115,8 @@ ITC_Status_t ITC_Id_sum(
 
 #endif /* !ITC_CONFIG_ENABLE_EXTENDED_API */
 
+#if IS_UNIT_TEST_BUILD
+
 /**
  * @brief Normalise an ID
  *
@@ -125,5 +127,7 @@ ITC_Status_t ITC_Id_sum(
 ITC_Status_t ITC_Id_normalise(
     ITC_Id_t *pt_Id
 );
+
+#endif /* IS_UNIT_TEST_BUILD */
 
 #endif /* ITC_ID_PACKAGE_H_ */

--- a/meson.build
+++ b/meson.build
@@ -68,7 +68,7 @@ else
     common_c_args += [ '-DIS_UNIT_TEST_BUILD=0' ]
 endif
 
-# Build LibITC
+# Build libitc
 subdir('libitc')
 subdir('libitc' / 'build')
 

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,14 @@ common_c_args = meson.get_compiler('c').get_supported_arguments([
 common_link_args = meson.get_compiler('c').get_supported_link_arguments([
 ])
 
+if get_option('tests')
+    # Let the compiler know this is a unit test build
+    common_c_args += [ '-DIS_UNIT_TEST_BUILD=1' ]
+else
+    # Let the compiler know this is not a unit test build
+    common_c_args += [ '-DIS_UNIT_TEST_BUILD=0' ]
+endif
+
 # Build LibITC
 subdir('libitc')
 subdir('libitc' / 'build')


### PR DESCRIPTION
Disables the following package APIs when not building unit tests:

- `ITC_Id_normalise`
- `ITC_Event_normalise`
- `ITC_Event_maximise`

The goal is to reduce the core lib size (when not built for unit testing). 

This is kind of a 'compromise' solution. Ideally, these APIs should not exist at all. However, removing them will also remove the ability to test the functionality directly, which makes testing for edge cases difficult.

Honestly, it's either this or adding a bunch of cumbersome and easy to break tests, which try to indirectly test for the edge cases in the normalisation/maximisation functionality.