### PR TITLE
Disable the extended API by default

### DIFF
--- a/libitc/include/ITC_config.h
+++ b/libitc/include/ITC_config.h
@@ -50,7 +50,7 @@
  *   * `ITC_Stamp_setId`
  *   * `ITC_Stamp_setEvent`
  */
-#define ITC_CONFIG_ENABLE_EXTENDED_API                                       (1)
+#define ITC_CONFIG_ENABLE_EXTENDED_API                                       (0)
 #endif
 
 #endif /* ITC_CONFIG_H_ */


### PR DESCRIPTION
The extended API is not part of the official ITC specification and is intended for advanced users.