### PR TITLE
Simplify itc api

### DIFF
--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -2048,31 +2048,51 @@ ITC_Status_t ITC_Event_validate(
  ******************************************************************************/
 
 ITC_Status_t ITC_Event_join(
-    const ITC_Event_t *const pt_Event1,
-    const ITC_Event_t *const pt_Event2,
-    ITC_Event_t **ppt_Event
+    ITC_Event_t **ppt_Event,
+    ITC_Event_t **ppt_OtherEvent
 )
 {
     ITC_Status_t t_Status = ITC_STATUS_SUCCESS; /* The current status */
+    ITC_Event_t *pt_JoinedEvent;
 
-    if (!ppt_Event)
+    if (!ppt_Event || !ppt_OtherEvent)
     {
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        t_Status = validateEvent(pt_Event1, true);
+        t_Status = validateEvent(*ppt_Event, true);
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        t_Status = validateEvent(pt_Event2, true);
+        t_Status = validateEvent(*ppt_OtherEvent, true);
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        t_Status = joinEventE(pt_Event1, pt_Event2, ppt_Event);
+        t_Status = joinEventE(*ppt_Event, *ppt_OtherEvent, &pt_JoinedEvent);
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        /* Destroy the second Event */
+        t_Status = ITC_Event_destroy(ppt_OtherEvent);
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        /* Save the parent pointer in case the original Event was a subtree */
+        pt_JoinedEvent->pt_Parent = (*ppt_Event)->pt_Parent;
+
+        /* Destroy the first Event */
+        t_Status = ITC_Event_destroy(ppt_Event);
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        *ppt_Event = pt_JoinedEvent;
     }
 
     return t_Status;

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -1295,26 +1295,41 @@ ITC_Status_t ITC_Id_validate(
  ******************************************************************************/
 
 ITC_Status_t ITC_Id_split(
-    const ITC_Id_t *const pt_Id,
-    ITC_Id_t **ppt_Id1,
-    ITC_Id_t **ppt_Id2
+    ITC_Id_t **ppt_Id,
+    ITC_Id_t **ppt_OtherId
 )
 {
     ITC_Status_t t_Status = ITC_STATUS_SUCCESS; /* The current status */
+    ITC_Id_t *pt_NewId = NULL;
+    ITC_Id_t *pt_OriginalIdParent = NULL;
 
-    if (!ppt_Id1 || !ppt_Id2)
+    if (!ppt_Id || !ppt_OtherId)
     {
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        t_Status = validateId(pt_Id, true);
+        t_Status = validateId(*ppt_Id, true);
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        t_Status = splitIdI(pt_Id, ppt_Id1, ppt_Id2);
+        t_Status = splitIdI(*ppt_Id, &pt_NewId, ppt_OtherId);
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        /* Save the parent pointer in case the original ID was a subtree */
+        pt_OriginalIdParent = (*ppt_Id)->pt_Parent;
+
+        t_Status = ITC_Id_destroy(ppt_Id);
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        *ppt_Id = pt_NewId;
+        pt_NewId->pt_Parent = pt_OriginalIdParent;
     }
 
     return t_Status;

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -1301,7 +1301,6 @@ ITC_Status_t ITC_Id_split(
 {
     ITC_Status_t t_Status = ITC_STATUS_SUCCESS; /* The current status */
     ITC_Id_t *pt_NewId = NULL;
-    ITC_Id_t *pt_OriginalIdParent = NULL;
 
     if (!ppt_Id || !ppt_OtherId)
     {
@@ -1321,7 +1320,7 @@ ITC_Status_t ITC_Id_split(
     if (t_Status == ITC_STATUS_SUCCESS)
     {
         /* Save the parent pointer in case the original ID was a subtree */
-        pt_OriginalIdParent = (*ppt_Id)->pt_Parent;
+        pt_NewId->pt_Parent = (*ppt_Id)->pt_Parent;
 
         t_Status = ITC_Id_destroy(ppt_Id);
     }
@@ -1329,7 +1328,6 @@ ITC_Status_t ITC_Id_split(
     if (t_Status == ITC_STATUS_SUCCESS)
     {
         *ppt_Id = pt_NewId;
-        pt_NewId->pt_Parent = pt_OriginalIdParent;
     }
 
     return t_Status;
@@ -1340,31 +1338,51 @@ ITC_Status_t ITC_Id_split(
  ******************************************************************************/
 
 ITC_Status_t ITC_Id_sum(
-    const ITC_Id_t *const pt_Id1,
-    const ITC_Id_t *const pt_Id2,
-    ITC_Id_t **ppt_Id
+    ITC_Id_t **ppt_Id,
+    ITC_Id_t **ppt_OtherId
 )
 {
     ITC_Status_t t_Status = ITC_STATUS_SUCCESS; /* The current status */
+    ITC_Id_t *pt_SummedId = NULL;
 
-    if (!ppt_Id)
+    if (!ppt_Id || !ppt_OtherId)
     {
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        t_Status = validateId(pt_Id1, true);
+        t_Status = validateId(*ppt_Id, true);
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        t_Status = validateId(pt_Id2, true);
+        t_Status = validateId(*ppt_OtherId, true);
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        t_Status = sumIdI(pt_Id1, pt_Id2, ppt_Id);
+        t_Status = sumIdI(*ppt_Id, *ppt_OtherId, &pt_SummedId);
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        /* Destroy the second ID */
+        t_Status = ITC_Id_destroy(ppt_OtherId);
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        /* Save the parent pointer in case the original ID was a subtree */
+        pt_SummedId->pt_Parent = (*ppt_Id)->pt_Parent;
+
+        /* Destroy the first ID */
+        t_Status = ITC_Id_destroy(ppt_Id);
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        *ppt_Id = pt_SummedId;
     }
 
     return t_Status;

--- a/libitc/include/ITC_Id_prototypes.h
+++ b/libitc/include/ITC_Id_prototypes.h
@@ -100,6 +100,9 @@ ITC_Status_t ITC_Id_split(
 /**
  * @brief Sum two existing IDs into a single ID
  *
+ * @note On success, `ppt_OtherId` will be automatically deallocated to prevent
+ * it from being used again accidentally (as well as to reduce developer
+ * cleanup burden)
  * @param ppt_Id (in) The first existing ID. (out) The summed ID
  * @param ppt_OtherId (in) The second existing ID. (out) NULL
  * @return `ITC_Status_t` The status of the operation

--- a/libitc/include/ITC_Id_prototypes.h
+++ b/libitc/include/ITC_Id_prototypes.h
@@ -100,16 +100,14 @@ ITC_Status_t ITC_Id_split(
 /**
  * @brief Sum two existing IDs into a single ID
  *
- * @param pt_Id1 The first ID
- * @param pt_Id2 The second ID
- * @param ppt_Id (out) The pointer to the summed ID
+ * @param ppt_Id (in) The first existing ID. (out) The summed ID
+ * @param ppt_OtherId (in) The second existing ID. (out) NULL
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_sum(
-    const ITC_Id_t *const pt_Id1,
-    const ITC_Id_t *const pt_Id2,
-    ITC_Id_t **ppt_Id
+    ITC_Id_t **ppt_Id,
+    ITC_Id_t **ppt_OtherId
 );
 
 #endif /* ITC_CONFIG_ENABLE_EXTENDED_API */

--- a/libitc/include/ITC_Id_prototypes.h
+++ b/libitc/include/ITC_Id_prototypes.h
@@ -87,16 +87,14 @@ ITC_Status_t ITC_Id_validate(
 /**
  * @brief Split an existing ITC ID into two distinct (non-overlaping) ITC IDs
  *
- * @param pt_Id The existing ID
- * @param ppt_Id1 (out) The pointer to the first split ID
- * @param ppt_Id2 (out) The pointer to the second split  ID
+ * @param ppt_Id (in) The existing ID. (out) The first split ID
+ * @param ppt_Id2 (out) The second split ID
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_split(
-    const ITC_Id_t *const pt_Id,
-    ITC_Id_t **ppt_Id1,
-    ITC_Id_t **ppt_Id2
+    ITC_Id_t **ppt_Id,
+    ITC_Id_t **ppt_OtherId
 );
 
 /**

--- a/libitc/include/ITC_Id_prototypes.h
+++ b/libitc/include/ITC_Id_prototypes.h
@@ -88,7 +88,7 @@ ITC_Status_t ITC_Id_validate(
  * @brief Split an existing ITC ID into two distinct (non-overlaping) ITC IDs
  *
  * @param ppt_Id (in) The existing ID. (out) The first split ID
- * @param ppt_Id2 (out) The second split ID
+ * @param ppt_OtherId (out) The second split ID
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
  */

--- a/libitc/include/ITC_Stamp_prototypes.h
+++ b/libitc/include/ITC_Stamp_prototypes.h
@@ -75,16 +75,14 @@ ITC_Status_t ITC_Stamp_clone(
  * Creates 2 stamps with distinct (non-overlaping) IDs and the same
  * event history.
  *
- * @param pt_Stamp The existing Stamp
- * @param ppt_Stamp1 (out) The first Stamp
- * @param ppt_Stamp2 (out) The second Stamp
+ * @param ppt_Stamp (in) The existing Stamp. (out) The first forked Stamp
+ * @param ppt_OtherStamp (out) The second forked Stamp
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_fork(
-    const ITC_Stamp_t *const pt_Stamp,
-    ITC_Stamp_t **ppt_Stamp1,
-    ITC_Stamp_t **ppt_Stamp2
+    ITC_Stamp_t **ppt_Stamp,
+    ITC_Stamp_t **ppt_OtherStamp
 );
 
 /**
@@ -105,16 +103,14 @@ ITC_Status_t ITC_Stamp_event(
  * @brief Join two existing Stamps
  * Joins 2 stamps into a single Stamp, combining their IDs and event histories.
  *
- * @param pt_Stamp1 The first Stamp
- * @param pt_Stamp2 The second Stamp
- * @param ppt_Stamp (out) The pointer to the joined Stamp
+ * @param ppt_Stamp (in) The first existing Stamp. (out) The joined Stamp
+ * @param ppt_OtherStamp (in) The second existing Stamp. (out) NULL
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Stamp_join(
-    const ITC_Stamp_t *const pt_Stamp1,
-    const ITC_Stamp_t *const pt_Stamp2,
-    ITC_Stamp_t **ppt_Stamp
+    ITC_Stamp_t **ppt_Stamp,
+    ITC_Stamp_t **ppt_OtherStamp
 );
 
 /**

--- a/libitc/include/ITC_Stamp_prototypes.h
+++ b/libitc/include/ITC_Stamp_prototypes.h
@@ -103,6 +103,9 @@ ITC_Status_t ITC_Stamp_event(
  * @brief Join two existing Stamps
  * Joins 2 stamps into a single Stamp, combining their IDs and event histories.
  *
+ * @note On success, `ppt_OtherStamp` will be automatically deallocated to
+ * prevent it from being used again accidentally (as well as to reduce developer
+ * cleanup burden)
  * @param ppt_Stamp (in) The first existing Stamp. (out) The joined Stamp
  * @param ppt_OtherStamp (in) The second existing Stamp. (out) NULL
  * @return `ITC_Status_t` The status of the operation

--- a/libitc/package-include/ITC_Event_package.h
+++ b/libitc/package-include/ITC_Event_package.h
@@ -79,6 +79,9 @@ ITC_Status_t ITC_Event_validate(
 /**
  * @brief Join two existing Events into a single Event
  *
+ * @note On success, `ppt_OtherEvent` will be automatically deallocated to
+ * prevent it from being used again accidentally (as well as to reduce developer
+ * cleanup burden)
  * @param ppt_Event (in) The first existing Event. (out) The joined Event
  * @param ppt_OtherEvent (in) The second existing Event. (out) NULL
  * @return `ITC_Status_t` The status of the operation

--- a/libitc/package-include/ITC_Event_package.h
+++ b/libitc/package-include/ITC_Event_package.h
@@ -79,16 +79,14 @@ ITC_Status_t ITC_Event_validate(
 /**
  * @brief Join two existing Events into a single Event
  *
- * @param pt_Event1 The first Event
- * @param pt_Event2 The second Event
- * @param ppt_Event (out) The pointer to the joined Event
+ * @param ppt_Event (in) The first existing Event. (out) The joined Event
+ * @param ppt_OtherEvent (in) The second existing Event. (out) NULL
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Event_join(
-    const ITC_Event_t *const pt_Event1,
-    const ITC_Event_t *const pt_Event2,
-    ITC_Event_t **ppt_Event
+    ITC_Event_t **ppt_Event,
+    ITC_Event_t **ppt_OtherEvent
 );
 
 /**

--- a/libitc/package-include/ITC_Id_package.h
+++ b/libitc/package-include/ITC_Id_package.h
@@ -87,7 +87,7 @@ ITC_Status_t ITC_Id_validate(
  * @brief Split an existing ITC ID into two distinct (non-overlaping) ITC IDs
  *
  * @param ppt_Id (in) The existing ID. (out) The first split ID
- * @param ppt_Id2 (out) The second split ID
+ * @param ppt_OtherId (out) The second split ID
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
  */

--- a/libitc/package-include/ITC_Id_package.h
+++ b/libitc/package-include/ITC_Id_package.h
@@ -99,6 +99,9 @@ ITC_Status_t ITC_Id_split(
 /**
  * @brief Sum two existing IDs into a single ID
  *
+ * @note On success, `ppt_OtherId` will be automatically deallocated to prevent
+ * it from being used again accidentally (as well as to reduce developer
+ * cleanup burden)
  * @param ppt_Id (in) The first existing ID. (out) The summed ID
  * @param ppt_OtherId (in) The second existing ID. (out) NULL
  * @return `ITC_Status_t` The status of the operation

--- a/libitc/package-include/ITC_Id_package.h
+++ b/libitc/package-include/ITC_Id_package.h
@@ -99,16 +99,14 @@ ITC_Status_t ITC_Id_split(
 /**
  * @brief Sum two existing IDs into a single ID
  *
- * @param pt_Id1 The first ID
- * @param pt_Id2 The second ID
- * @param ppt_Id (out) The pointer to the summed ID
+ * @param ppt_Id (in) The first existing ID. (out) The summed ID
+ * @param ppt_OtherId (in) The second existing ID. (out) NULL
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_sum(
-    const ITC_Id_t *const pt_Id1,
-    const ITC_Id_t *const pt_Id2,
-    ITC_Id_t **ppt_Id
+    ITC_Id_t **ppt_Id,
+    ITC_Id_t **ppt_OtherId
 );
 
 #endif /* !ITC_CONFIG_ENABLE_EXTENDED_API */

--- a/libitc/package-include/ITC_Id_package.h
+++ b/libitc/package-include/ITC_Id_package.h
@@ -86,16 +86,14 @@ ITC_Status_t ITC_Id_validate(
 /**
  * @brief Split an existing ITC ID into two distinct (non-overlaping) ITC IDs
  *
- * @param pt_Id The existing ID
- * @param ppt_Id1 (out) The pointer to the first split ID
- * @param ppt_Id2 (out) The pointer to the second split  ID
+ * @param ppt_Id (in) The existing ID. (out) The first split ID
+ * @param ppt_Id2 (out) The second split ID
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
  */
 ITC_Status_t ITC_Id_split(
-    const ITC_Id_t *const pt_Id,
-    ITC_Id_t **ppt_Id1,
-    ITC_Id_t **ppt_Id2
+    ITC_Id_t **ppt_Id,
+    ITC_Id_t **ppt_OtherId
 );
 
 /**

--- a/libitc/test/mocked/ITC_Event_Test.c
+++ b/libitc/test/mocked/ITC_Event_Test.c
@@ -182,43 +182,9 @@ void ITC_Event_Test_normaliseEventIsRecoveredOnFailure(void)
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(gpt_ParentEvent->pt_Right, 2);
 }
 
-/* Test successful joining of two Events is properly cleaned up */
-void ITC_Event_Test_joinCopiedSourceEventsAreDestroyedOnExit(void)
-{
-    ITC_Event_t *pt_SummedEvent;
-    ITC_Event_t t_NewEvent1 = { 0 };
-    ITC_Event_t *pt_NewEvent1 = &t_NewEvent1;
-    ITC_Event_t t_NewEvent2 = { 0 };
-    ITC_Event_t *pt_NewEvent2 = &t_NewEvent2;
-    ITC_Event_t t_NewEvent3 = { 0 };
-    ITC_Event_t *pt_NewEvent3 = &t_NewEvent3;
-
-    /* Setup expectations */
-    ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Event_t), ITC_STATUS_SUCCESS);
-    ITC_Port_malloc_IgnoreArg_ppv_Ptr();
-    ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewEvent1);
-
-    ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Event_t), ITC_STATUS_SUCCESS);
-    ITC_Port_malloc_IgnoreArg_ppv_Ptr();
-    ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewEvent2);
-
-    ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Event_t), ITC_STATUS_SUCCESS);
-    ITC_Port_malloc_IgnoreArg_ppv_Ptr();
-    ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewEvent3);
-
-    ITC_Port_free_ExpectAndReturn(pt_NewEvent1, ITC_STATUS_SUCCESS);
-    ITC_Port_free_ExpectAndReturn(pt_NewEvent2, ITC_STATUS_SUCCESS);
-
-    /* Test joining the Events */
-    TEST_SUCCESS(ITC_Event_join(gpt_LeafEvent, gpt_LeafEvent, &pt_SummedEvent));
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SummedEvent, 0);
-}
-
 /* Test failed summing of two Events is properly cleaned up */
 void ITC_Event_Test_joinedEventIsDestroyedOnFailure(void)
 {
-    ITC_Event_t *pt_SummedEvent;
-
     ITC_Event_t rt_NewEvent[3] = { 0 };
     ITC_Event_t *rpt_NewEvent[] = {
         &rt_NewEvent[0],
@@ -310,8 +276,44 @@ void ITC_Event_Test_joinedEventIsDestroyedOnFailure(void)
 
     /* Test failing to join the Events */
     TEST_FAILURE(
-        ITC_Event_join(gpt_ParentEvent, gpt_LeafEvent, &pt_SummedEvent),
+        ITC_Event_join(&gpt_ParentEvent, &gpt_LeafEvent),
         ITC_STATUS_FAILURE);
+}
+
+/* Test successful joining of two Events is properly cleaned up */
+void ITC_Event_Test_joinOriginalAndCopiedEventsAreDestroyedOnSucess(void)
+{
+    ITC_Event_t t_OtherEvent = gt_LeafNode;
+    ITC_Event_t *pt_OtherEvent = &t_OtherEvent;
+
+    ITC_Event_t t_NewEvent1 = { 0 };
+    ITC_Event_t *pt_NewEvent1 = &t_NewEvent1;
+    ITC_Event_t t_NewEvent2 = { 0 };
+    ITC_Event_t *pt_NewEvent2 = &t_NewEvent2;
+    ITC_Event_t t_NewEvent3 = { 0 };
+    ITC_Event_t *pt_NewEvent3 = &t_NewEvent3;
+
+    /* Setup expectations */
+    ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Event_t), ITC_STATUS_SUCCESS);
+    ITC_Port_malloc_IgnoreArg_ppv_Ptr();
+    ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewEvent1);
+
+    ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Event_t), ITC_STATUS_SUCCESS);
+    ITC_Port_malloc_IgnoreArg_ppv_Ptr();
+    ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewEvent2);
+
+    ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Event_t), ITC_STATUS_SUCCESS);
+    ITC_Port_malloc_IgnoreArg_ppv_Ptr();
+    ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewEvent3);
+
+    ITC_Port_free_ExpectAndReturn(pt_NewEvent1, ITC_STATUS_SUCCESS);
+    ITC_Port_free_ExpectAndReturn(pt_NewEvent2, ITC_STATUS_SUCCESS);
+    ITC_Port_free_ExpectAndReturn(pt_OtherEvent, ITC_STATUS_SUCCESS);
+    ITC_Port_free_ExpectAndReturn(gpt_LeafEvent, ITC_STATUS_SUCCESS);
+
+    /* Test joining the Events */
+    TEST_SUCCESS(ITC_Event_join(&gpt_LeafEvent, &pt_OtherEvent));
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(gpt_LeafEvent, 0);
 }
 
 /* Test failed maximise an Event is properly recovered from */

--- a/libitc/test/mocked/ITC_Id_Test.c
+++ b/libitc/test/mocked/ITC_Id_Test.c
@@ -227,7 +227,7 @@ void ITC_Id_Test_splitIdOriginalIdIsDestroyedOnSuccess(void)
 
     ITC_Port_free_ExpectAndReturn(gpt_LeafId, ITC_STATUS_SUCCESS);
 
-    /* Test failing to split a null ID */
+    /* Test splitting the ID */
     gpt_LeafId->b_IsOwner = false;
     TEST_SUCCESS(ITC_Id_split(&gpt_LeafId, &pt_OtherId));
 }
@@ -266,7 +266,6 @@ void ITC_Id_Test_normaliseIdIsRecoveredOnFailure(void)
 /* Test failed summing of two IDs is properly cleaned up */
 void ITC_Id_Test_sumIdAreDestroyedOnFailure(void)
 {
-    ITC_Id_t *pt_SummedId;
     ITC_Id_t t_NewId1 = { 0 };
     ITC_Id_t *pt_NewId1 = &t_NewId1;
     ITC_Id_t t_NewId2 = { 0 };
@@ -276,6 +275,8 @@ void ITC_Id_Test_sumIdAreDestroyedOnFailure(void)
     /* Mirror the global test ID */
     ITC_Id_t t_OtherIdLeftChild = gt_RightLeafOfParentId;
     ITC_Id_t t_OtherIdRightChild = gt_LeftLeafOfParentId;
+
+    ITC_Id_t *pt_OtherId = &t_OtherId;
 
     /* Fix pointers */
     t_OtherId.pt_Left = &t_OtherIdLeftChild;
@@ -299,12 +300,7 @@ void ITC_Id_Test_sumIdAreDestroyedOnFailure(void)
     ITC_Port_free_ExpectAndReturn(pt_NewId1, ITC_STATUS_SUCCESS);
 
     /* Test summing the IDs */
-    TEST_FAILURE(
-        ITC_Id_sum(
-            gpt_ParentId,
-            &t_OtherId,
-            &pt_SummedId),
-        ITC_STATUS_FAILURE);
+    TEST_FAILURE(ITC_Id_sum(&gpt_ParentId, &pt_OtherId), ITC_STATUS_FAILURE);
 
     /* Setup expectations */
     ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Id_t), ITC_STATUS_SUCCESS);
@@ -324,8 +320,30 @@ void ITC_Id_Test_sumIdAreDestroyedOnFailure(void)
     /* Test summing the IDs the other way around */
     TEST_FAILURE(
         ITC_Id_sum(
-            &t_OtherId,
-            gpt_ParentId,
-            &pt_SummedId),
+            &pt_OtherId,
+            &gpt_ParentId),
         ITC_STATUS_FAILURE);
+}
+
+/* Test original IDs are destroyed when summed */
+void ITC_Id_Test_sumIdOriginalIdsAreDestroyedOnSuccess(void)
+{
+    ITC_Id_t t_OtherId = gt_LeafNode;
+    ITC_Id_t *pt_OtherId = &t_OtherId;
+
+    ITC_Id_t t_NewId1 = {0};
+    ITC_Id_t *pt_NewId1 = &t_NewId1;
+
+    /* Setup expectations */
+    ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Id_t), ITC_STATUS_SUCCESS);
+    ITC_Port_malloc_IgnoreArg_ppv_Ptr();
+    ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewId1);
+
+    ITC_Port_free_ExpectAndReturn(pt_OtherId, ITC_STATUS_SUCCESS);
+    ITC_Port_free_ExpectAndReturn(gpt_LeafId, ITC_STATUS_SUCCESS);
+
+    /* Test summing the IDs */
+    pt_OtherId->b_IsOwner = false;
+    gpt_LeafId->b_IsOwner = true;
+    TEST_SUCCESS(ITC_Id_sum(&gpt_LeafId, &pt_OtherId));
 }

--- a/libitc/test/mocked/ITC_Id_Test.c
+++ b/libitc/test/mocked/ITC_Id_Test.c
@@ -138,8 +138,7 @@ void ITC_Id_Test_clonedIdIsDestroyedOnFailure(void)
 /* Test failed splitting of an ID is properly cleaned up */
 void ITC_Id_Test_splitIdsAreDestroyedOnFailure(void)
 {
-    ITC_Id_t *pt_SplitId1;
-    ITC_Id_t *pt_SplitId2;
+    ITC_Id_t *pt_OtherId;
 
     ITC_Id_t t_NewId1 = {0};
     ITC_Id_t *pt_NewId1 = &t_NewId1;
@@ -161,9 +160,8 @@ void ITC_Id_Test_splitIdsAreDestroyedOnFailure(void)
     gpt_LeafId->b_IsOwner = false;
     TEST_FAILURE(
         ITC_Id_split(
-            gpt_LeafId,
-            &pt_SplitId1,
-            &pt_SplitId2),
+            &gpt_LeafId,
+            &pt_OtherId),
         ITC_STATUS_FAILURE);
 
     /* Setup expectations */
@@ -180,9 +178,8 @@ void ITC_Id_Test_splitIdsAreDestroyedOnFailure(void)
     gpt_LeafId->b_IsOwner = true;
     TEST_FAILURE(
         ITC_Id_split(
-            gpt_LeafId,
-            &pt_SplitId1,
-            &pt_SplitId2),
+            &gpt_LeafId,
+            &pt_OtherId),
         ITC_STATUS_FAILURE);
 
     /* Setup expectations */
@@ -203,10 +200,36 @@ void ITC_Id_Test_splitIdsAreDestroyedOnFailure(void)
     /* Test failing to split a (0, 1) ID */
     TEST_FAILURE(
         ITC_Id_split(
-            gpt_ParentId,
-            &pt_SplitId1,
-            &pt_SplitId2),
+            &gpt_ParentId,
+            &pt_OtherId),
         ITC_STATUS_FAILURE);
+}
+
+/* Test original ID is destroyed when split */
+void ITC_Id_Test_splitIdOriginalIdIsDestroyedOnSuccess(void)
+{
+    ITC_Id_t *pt_OtherId;
+
+    ITC_Id_t t_NewId1 = {0};
+    ITC_Id_t *pt_NewId1 = &t_NewId1;
+
+    ITC_Id_t t_NewId2 = {0};
+    ITC_Id_t *pt_NewId2 = &t_NewId2;
+
+    /* Setup expectations */
+    ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Id_t), ITC_STATUS_SUCCESS);
+    ITC_Port_malloc_IgnoreArg_ppv_Ptr();
+    ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewId1);
+
+    ITC_Port_malloc_ExpectAndReturn(NULL, sizeof(ITC_Id_t), ITC_STATUS_SUCCESS);
+    ITC_Port_malloc_IgnoreArg_ppv_Ptr();
+    ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewId2);
+
+    ITC_Port_free_ExpectAndReturn(gpt_LeafId, ITC_STATUS_SUCCESS);
+
+    /* Test failing to split a null ID */
+    gpt_LeafId->b_IsOwner = false;
+    TEST_SUCCESS(ITC_Id_split(&gpt_LeafId, &pt_OtherId));
 }
 
 /* Test failed normalisation of an ID is properly recovered from */

--- a/libitc/test/normal/ITC_Id_Test.c
+++ b/libitc/test/normal/ITC_Id_Test.c
@@ -226,19 +226,16 @@ void ITC_Id_Test_splitIdFailInvalidParam(void)
   ITC_Id_t *pt_DummyId = NULL;
 
   TEST_FAILURE(
-    ITC_Id_split(NULL, &pt_DummyId, &pt_DummyId), ITC_STATUS_INVALID_PARAM);
+    ITC_Id_split(NULL, &pt_DummyId), ITC_STATUS_INVALID_PARAM);
   TEST_FAILURE(
-    ITC_Id_split(pt_DummyId, NULL, &pt_DummyId), ITC_STATUS_INVALID_PARAM);
-  TEST_FAILURE(
-    ITC_Id_split(pt_DummyId, &pt_DummyId, NULL), ITC_STATUS_INVALID_PARAM);
+    ITC_Id_split(&pt_DummyId, NULL), ITC_STATUS_INVALID_PARAM);
 }
 
 /* Test splitting an ID fails with corrupt ID */
 void ITC_Id_Test_splitIdFailWithCorruptId(void)
 {
     ITC_Id_t *pt_Id;
-    ITC_Id_t *pt_SplitId1;
-    ITC_Id_t *pt_SplitId2;
+    ITC_Id_t *pt_OtherId;
 
     /* Test different invalid IDs are handled properly */
     for (uint32_t u32_I = 0;
@@ -249,447 +246,390 @@ void ITC_Id_Test_splitIdFailWithCorruptId(void)
         gpv_InvalidIdConstructorTable[u32_I](&pt_Id);
 
         /* Test for the failure */
-        TEST_FAILURE(
-            ITC_Id_split(pt_Id, &pt_SplitId1, &pt_SplitId2),
-            ITC_STATUS_CORRUPT_ID);
+        TEST_FAILURE(ITC_Id_split(&pt_Id, &pt_OtherId), ITC_STATUS_CORRUPT_ID);
 
         /* Destroy the ID */
         gpv_InvalidIdDestructorTable[u32_I](&pt_Id);
     }
 }
 
-/* Test splitting a NULL and seed IDs succeeds */
+/* Test splitting a null and seed IDs succeeds */
 void ITC_Id_Test_splitNullAndSeedIdsSuccessful(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1 = NULL;
-    ITC_Id_t *pt_SplitId2 = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* Create a new NULL ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
+    /* Create a new null ID */
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
 
-    /* Split the NULL ID */
-    TEST_SUCCESS(ITC_Id_split(pt_OriginalId, &pt_SplitId1, &pt_SplitId2));
+    /* Split the null ID */
+    TEST_SUCCESS(ITC_Id_split(&pt_Id, &pt_OtherId));
 
     /* Test the new IDs match (0, 0) */
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2);
-
-    /* Test the original is still a NULL ID */
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 
-    /* Change the ID into a seed ID */
-    pt_OriginalId->b_IsOwner = true;
+    /* Create a new seed ID */
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id, NULL));
 
     /* Split the seed ID */
-    TEST_SUCCESS(ITC_Id_split(pt_OriginalId, &pt_SplitId1, &pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id, &pt_OtherId));
 
     /* Test the new IDs match ((1, 0), (0, 1)) */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2);
-
-    /* Test the original is still a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_OriginalId);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test splitting a NULL and seed ID subtrees succeeds */
 void ITC_Id_Test_splitNullAndSeedIdSubtreesSuccessful(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1 = NULL;
-    ITC_Id_t *pt_SplitId2 = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* clang-format off */
-    /* Create a new NULL ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Right, pt_OriginalId));
-    /* clang-format on */
+    /* Create a new (0, 1) ID */
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right, pt_Id));
 
     /* Split the NULL ID */
-    TEST_SUCCESS(ITC_Id_split(
-        pt_OriginalId->pt_Left, &pt_SplitId1, &pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Left, &pt_OtherId));
 
     /* Test the new IDs match (0, 0) */
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId);
 
-    /* Test the original is still a NULL ID */
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId->pt_Left);
+    /* Test the rest of the original ID hasn't changed */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_SEED_ID(pt_Id->pt_Right);
 
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    /* Destroy the other ID */
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 
     /* Split the seed ID */
-    TEST_SUCCESS(ITC_Id_split(
-        pt_OriginalId->pt_Right, &pt_SplitId1, &pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Right, &pt_OtherId));
 
     /* Test the new IDs match ((1, 0), (0, 1)) */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Right);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId);
 
-    /* Test the original is still a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_OriginalId->pt_Right);
+    /* Test the rest of the original ID hasn't changed */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test splitting a (0, 1) and (1, 0) ID succeeds */
 void ITC_Id_Test_split01And10IdsSuccessful(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1 = NULL;
-    ITC_Id_t *pt_SplitId2 = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* clang-format off */
     /* Create a new (0, 1) ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Right, pt_OriginalId));
-    /* clang-format on */
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right, pt_Id));
 
     /* Split the (0, 1) ID */
-    TEST_SUCCESS(ITC_Id_split(pt_OriginalId, &pt_SplitId1, &pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id, &pt_OtherId));
 
-    /* Test the new IDs match ((0, (1, 0)), (0, (0, 1))) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Left);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1->pt_Right);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Left);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2->pt_Right);
-
-    /* Test the original is still a (0, 1) ID */
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId->pt_Left);
-    TEST_ITC_ID_IS_SEED_ID(pt_OriginalId->pt_Right);
+    /* Test the split IDs match ((0, (1, 0)), (0, (0, 1))) */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Right);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 
-    /* Change the ID into (1, 0) ID */
-    pt_OriginalId->pt_Left->b_IsOwner = true;
-    pt_OriginalId->pt_Right->b_IsOwner = false;
+    /* Create a new (1, 0) ID */
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
 
     /* Split the (1, 0) ID */
-    TEST_SUCCESS(ITC_Id_split(pt_OriginalId, &pt_SplitId1, &pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id, &pt_OtherId));
 
-    /* Test the new IDs match (((1, 0), 0), ((0, 1), 0)) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Right);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Right);
-
-    /* Test the original is still a (1, 0) ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_OriginalId->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId->pt_Right);
+    /* Test the split IDs match (((1, 0), 0), ((0, 1), 0)) */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Right);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test splitting a (0, 1) and (1, 0) ID subtrees succeeds */
 void ITC_Id_Test_split01And10IdSubtreesSuccessful(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1 = NULL;
-    ITC_Id_t *pt_SplitId2 = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId = NULL;
 
     /* clang-format off */
-    /* Create a new (0, 1) ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right->pt_Left, pt_OriginalId->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Right->pt_Right, pt_OriginalId->pt_Right));
+    /* Create a new (0, 1) ID subtree */
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
+
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Left, pt_Id->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Right, pt_Id->pt_Right));
     /* clang-format on */
 
-    /* Split the (0, 1) ID */
-    TEST_SUCCESS(
-        ITC_Id_split(pt_OriginalId->pt_Right, &pt_SplitId1, &pt_SplitId2));
+    /* Split the (0, 1) ID subtree */
+    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Right, &pt_OtherId));
 
-    /* Test the new IDs match ((0, (1, 0)), (0, (0, 1))) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Left);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1->pt_Right);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Left);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2->pt_Right);
+    /* Test the split IDs match ((0, (1, 0)), (0, (0, 1))) */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id->pt_Right);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right->pt_Left);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Right->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Right);
 
-    /* Test the original is still a (0, 1) ID */
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId->pt_Right->pt_Left);
-    TEST_ITC_ID_IS_SEED_ID(pt_OriginalId->pt_Right->pt_Right);
+    /* Test the rest of the original ID hasn't changed */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id->pt_Right));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 
-    /* Change the ID into (1, 0) ID */
-    pt_OriginalId->pt_Right->pt_Left->b_IsOwner = true;
-    pt_OriginalId->pt_Right->pt_Right->b_IsOwner = false;
+    /* clang-format off */
+    /* Create a new (1, 0) ID subtree */
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Left, pt_Id->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Right, pt_Id->pt_Right));
+    /* clang-format on */
 
-    /* Split the (1, 0) ID */
-    TEST_SUCCESS(
-        ITC_Id_split(pt_OriginalId->pt_Right, &pt_SplitId1, &pt_SplitId2));
+    /* Split the (1, 0) ID subtree */
+    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Right, &pt_OtherId));
 
     /* Test the new IDs match (((1, 0), 0), ((0, 1), 0)) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Right);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Right);
-
-    /* Test the original is still a (1, 0) ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_OriginalId->pt_Right->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId->pt_Right->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id->pt_Right);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Right->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Right);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test splitting a (0, (1, 0)) ID succeeds */
 void ITC_Id_Test_split010RIdSuccessful(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1 = NULL;
-    ITC_Id_t *pt_SplitId2 = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId = NULL;
 
     /* clang-format off */
     /* Create a new (0, (1, 0)) ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left, pt_OriginalId));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Right->pt_Left, pt_OriginalId->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right->pt_Right, pt_OriginalId->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Left, pt_Id->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Right, pt_Id->pt_Right));
     /* clang-format on */
 
     /* Split the (0, (1, 0)) ID */
-    TEST_SUCCESS(ITC_Id_split(pt_OriginalId, &pt_SplitId1, &pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id, &pt_OtherId));
 
-    /* Test the new IDs match ((0, ((1, 0), 0)), (0, ((0, 1), 0))) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Left);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1->pt_Right);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1->pt_Right->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Right->pt_Right);
+    /* Test the split IDs match ((0, ((1, 0), 0)), (0, ((0, 1), 0))) */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id->pt_Right);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Right->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right->pt_Right);
 
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Left);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2->pt_Right);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2->pt_Right->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Right->pt_Right);
-
-    /* Test the original is still a (0, (1, 0)) ID */
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId->pt_Left);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_OriginalId->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId->pt_Right);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Right->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Right->pt_Right);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test splitting a ((0, 1), 0) ID succeeds */
 void ITC_Id_Test_split010LIdSuccessful(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1 = NULL;
-    ITC_Id_t *pt_SplitId2 = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
     /* clang-format off */
     /* Create a new ((0, 1), 0) ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Left, pt_OriginalId->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Left->pt_Right, pt_OriginalId->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Left, pt_Id->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left->pt_Right, pt_Id->pt_Left));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right, pt_OriginalId));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
     /* clang-format on */
 
     /* Split the ((0, 1), 0) ID */
-    TEST_SUCCESS(ITC_Id_split(pt_OriginalId, &pt_SplitId1, &pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id, &pt_OtherId));
 
-    /* Test the new IDs match (((0, (1, 0)), 0), ((0, (0, 1)), 0)) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Left->pt_Left);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1->pt_Left->pt_Right);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Right);
+    /* Test the split IDs match (((0, (1, 0)), 0), ((0, (0, 1)), 0)) */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left->pt_Left);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Left->pt_Right);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
 
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Left->pt_Left);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2->pt_Left->pt_Right);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Right);
-
-    /* Test the original is still a ((0, 1), 0) ID */
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OriginalId->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left->pt_Left);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Left->pt_Right);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Right);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test splitting a ((1, 0), (0, 1)) ID succeeds */
 void ITC_Id_Test_split1001IdSuccessful(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1 = NULL;
-    ITC_Id_t *pt_SplitId2 = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
     /* clang-format off */
     /* Create a new ((1, 0), (0, 1)) ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Left->pt_Left, pt_OriginalId->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Right, pt_OriginalId->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left->pt_Left, pt_Id->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right, pt_Id->pt_Left));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right->pt_Left, pt_OriginalId->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Right->pt_Right, pt_OriginalId->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Left, pt_Id->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Right, pt_Id->pt_Right));
     /* clang-format on */
 
     /* Split the ((1, 0), (0, 1)) ID */
-    TEST_SUCCESS(ITC_Id_split(pt_OriginalId, &pt_SplitId1, &pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id, &pt_OtherId));
 
-    /* Test the new IDs match (((1, 0), 0), (0, (0, 1))) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Right);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Left);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2->pt_Right);
-
-    /* Test the original is still a ((1, 0), (0, 1)) ID */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_OriginalId->pt_Left);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OriginalId->pt_Right);
+    /* Test the split IDs match (((1, 0), 0), (0, (0, 1))) */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Right);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test splitting a ((1, 0), (0, 1)) ID subtree succeeds */
 void ITC_Id_Test_split1001IdSubtreeSuccessful(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1 = NULL;
-    ITC_Id_t *pt_SplitId2 = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
     /* clang-format off */
-    /* Create a new ((1, 0), (0, 1)) ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right, pt_OriginalId));
+    /* Create a new ((1, 0), (0, 1)) ID subtree */
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Left, pt_OriginalId->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Left->pt_Left->pt_Left, pt_OriginalId->pt_Left->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Left->pt_Right, pt_OriginalId->pt_Left->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Left, pt_Id->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left->pt_Left->pt_Left, pt_Id->pt_Left->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Left->pt_Right, pt_Id->pt_Left->pt_Left));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Right, pt_OriginalId->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Right->pt_Left, pt_OriginalId->pt_Left->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Left->pt_Right->pt_Right, pt_OriginalId->pt_Left->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right, pt_Id->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right->pt_Left, pt_Id->pt_Left->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left->pt_Right->pt_Right, pt_Id->pt_Left->pt_Right));
+
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
     /* clang-format on */
 
-    /* Split the ((1, 0), (0, 1)) ID */
-    TEST_SUCCESS(
-        ITC_Id_split(pt_OriginalId->pt_Left, &pt_SplitId1, &pt_SplitId2));
+    /* Split the ((1, 0), (0, 1)) ID subtree */
+    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Left, &pt_OtherId));
 
-    /* Test the new IDs match (((1, 0), 0), (0, (0, 1))) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Right);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Left);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2->pt_Right);
+    /* Test the split IDs match (((1, 0), 0), (0, (0, 1))) */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id->pt_Left);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Left->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Right);
 
-    /* Test the original is still a ((1, 0), (0, 1)) ID */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_OriginalId->pt_Left->pt_Left);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OriginalId->pt_Left->pt_Right);
+    /* Test the rest of the original ID hasn't changed */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test splitting a ((0, (1, 0)), ((0, 1), 0)) ID succeeds */
 void ITC_Id_Test_split010010IdSuccessful(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1 = NULL;
-    ITC_Id_t *pt_SplitId2 = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
     /* clang-format off */
     /* Create a new ((0, (1, 0)), ((0, 1), 0)) ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Left, pt_OriginalId->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Right, pt_OriginalId->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Left->pt_Right->pt_Left, pt_OriginalId->pt_Left->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Right->pt_Right, pt_OriginalId->pt_Left->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Left, pt_Id->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right, pt_Id->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left->pt_Right->pt_Left, pt_Id->pt_Left->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right->pt_Right, pt_Id->pt_Left->pt_Right));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right->pt_Left, pt_OriginalId->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right->pt_Left->pt_Left, pt_OriginalId->pt_Right->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Right->pt_Left->pt_Right, pt_OriginalId->pt_Right->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right->pt_Right, pt_OriginalId->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Left, pt_Id->pt_Right));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Left->pt_Left, pt_Id->pt_Right->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Left->pt_Right, pt_Id->pt_Right->pt_Left));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Right, pt_Id->pt_Right));
     /* clang-format on */
 
     /* Split the ((0, (1, 0)), ((0, 1), 0)) ID */
-    TEST_SUCCESS(ITC_Id_split(pt_OriginalId, &pt_SplitId1, &pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id, &pt_OtherId));
 
-    /* Test the new IDs match (((0, (1, 0)), 0), (0, ((0, 1), 0))) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId1->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Left->pt_Left);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitId1->pt_Left->pt_Right);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId1->pt_Right);
+    /* Test the split IDs match (((0, (1, 0)), 0), (0, ((0, 1), 0))) */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left->pt_Left);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Left->pt_Right);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
 
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Left);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_SplitId2->pt_Right);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SplitId2->pt_Right->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_SplitId2->pt_Right->pt_Right);
-
-    /* Test the original is still a ((0, (1, 0)), ((0, 1), 0)) ID */
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId->pt_Left->pt_Left);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_OriginalId->pt_Left->pt_Right);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OriginalId->pt_Right->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_OriginalId->pt_Right->pt_Right);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId->pt_Right);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Right->pt_Left);
+    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Right->pt_Right);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test validating an ID fails with invalid param */
@@ -1586,109 +1526,88 @@ void ITC_Id_Test_sumId001110And110001Succeeds(void)
 /* Test splitting a seed ID several times and summing it back succeeds */
 void ITC_Id_Test_sumIdSplitSeedAndSumItBackToSeedSucceeds(void)
 {
-    ITC_Id_t *pt_OriginalId;
-    ITC_Id_t *pt_SplitId1;
-    ITC_Id_t *pt_SplitId11;
-    ITC_Id_t *pt_SplitId12;
-    ITC_Id_t *pt_SplitId111;
-    ITC_Id_t *pt_SplitId121;
-    ITC_Id_t *pt_SplitId112;
-    ITC_Id_t *pt_SplitId122;
-    ITC_Id_t *pt_SplitId2;
-    ITC_Id_t *pt_SplitId21;
-    ITC_Id_t *pt_SplitId22;
-    ITC_Id_t *pt_SplitId211;
-    ITC_Id_t *pt_SplitId221;
-    ITC_Id_t *pt_SplitId212;
-    ITC_Id_t *pt_SplitId222;
+    ITC_Id_t *pt_Id0;
+    ITC_Id_t *pt_Id1;
+    ITC_Id_t *pt_Id2;
+    ITC_Id_t *pt_Id3;
+    ITC_Id_t *pt_Id4;
+    ITC_Id_t *pt_Id5;
+    ITC_Id_t *pt_Id6;
+    ITC_Id_t *pt_Id7;
 
     ITC_Id_t *pt_SummedId = NULL;
     ITC_Id_t *pt_TmpId = NULL;
 
     /* Create the seed ID */
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id0, NULL));
 
     /* Split into (1, 0) and (0, 1) */
-    TEST_SUCCESS(ITC_Id_split(pt_OriginalId, &pt_SplitId1, &pt_SplitId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id0, &pt_Id4));
 
     /* Split into:
-     * - ((1, 0), 0)
-     * - (0, (1, 0))
-     * - ((0, 1), 0)
-     * - (0, (0, 1))
+     * pt_Id0 = (((1, 0), 0), 0)
+     * pt_Id1 = (((0, 1), 0), 0)
+     * pt_Id2 = ((0, (1, 0)), 0)
+     * pt_Id3 = ((0, (0, 1)), 0)
+     * pt_Id4 = (0, ((1, 0), 0))
+     * pt_Id5 = (0, ((0, 1), 0))
+     * pt_Id6 = (0, (0, (1, 0)))
+     * pt_Id7 = (0, (0, (0, 1)))
      */
-    TEST_SUCCESS(ITC_Id_split(pt_SplitId1, &pt_SplitId11, &pt_SplitId21));
-    TEST_SUCCESS(ITC_Id_split(pt_SplitId2, &pt_SplitId12, &pt_SplitId22));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId2));
-
-    /* Split into:
-     * - (((1, 0), 0), 0)
-     * - (0, ((1, 0), 0))
-     * - ((0, (1, 0)), 0)
-     * - (0, (0, (1, 0)))
-     * - (((0, 1), 0), 0)
-     * - (0, ((0, 1), 0))
-     * - ((0, (0, 1)), 0)
-     * - (0, (0, (0, 1)))
-     */
-    TEST_SUCCESS(ITC_Id_split(pt_SplitId11, &pt_SplitId111, &pt_SplitId211));
-    TEST_SUCCESS(ITC_Id_split(pt_SplitId12, &pt_SplitId112, &pt_SplitId212));
-    TEST_SUCCESS(ITC_Id_split(pt_SplitId21, &pt_SplitId121, &pt_SplitId221));
-    TEST_SUCCESS(ITC_Id_split(pt_SplitId22, &pt_SplitId122, &pt_SplitId222));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId11));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId12));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId21));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId22));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id0, &pt_Id2));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id0, &pt_Id1));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id2, &pt_Id3));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id4, &pt_Id6));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id4, &pt_Id5));
+    TEST_SUCCESS(ITC_Id_split(&pt_Id6, &pt_Id7));
 
     /* Sum them back into to a seed in arbitrary order */
 
-    TEST_SUCCESS(ITC_Id_sum(pt_SplitId222, pt_SplitId121, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId222));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId121));
+    TEST_SUCCESS(ITC_Id_sum(pt_Id0, pt_Id3, &pt_SummedId));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id0));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id3));
 
     TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
     TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
 
-    TEST_SUCCESS(ITC_Id_sum(pt_SplitId211, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId211));
+    TEST_SUCCESS(ITC_Id_sum(pt_Id5, pt_TmpId, &pt_SummedId));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id5));
     TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
 
     TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
 
     TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
 
-    TEST_SUCCESS(ITC_Id_sum(pt_SplitId122, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId122));
+    TEST_SUCCESS(ITC_Id_sum(pt_Id7, pt_TmpId, &pt_SummedId));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id7));
     TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
 
     TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
     TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
 
-    TEST_SUCCESS(ITC_Id_sum(pt_SplitId111, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId111));
+    TEST_SUCCESS(ITC_Id_sum(pt_Id6, pt_TmpId, &pt_SummedId));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id6));
     TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
 
     TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
     TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
 
-    TEST_SUCCESS(ITC_Id_sum(pt_SplitId221, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId221));
+    TEST_SUCCESS(ITC_Id_sum(pt_Id2, pt_TmpId, &pt_SummedId));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id2));
     TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
 
     TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
     TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
 
-    TEST_SUCCESS(ITC_Id_sum(pt_SplitId212, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId212));
+    TEST_SUCCESS(ITC_Id_sum(pt_Id4, pt_TmpId, &pt_SummedId));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id4));
     TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
 
     TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
     TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
 
-    TEST_SUCCESS(ITC_Id_sum(pt_SplitId112, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SplitId112));
+    TEST_SUCCESS(ITC_Id_sum(pt_Id1, pt_TmpId, &pt_SummedId));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id1));
     TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
 
     TEST_ITC_ID_IS_SEED_ID(pt_SummedId);

--- a/libitc/test/normal/ITC_Id_Test.c
+++ b/libitc/test/normal/ITC_Id_Test.c
@@ -225,10 +225,8 @@ void ITC_Id_Test_splitIdFailInvalidParam(void)
 {
   ITC_Id_t *pt_DummyId = NULL;
 
-  TEST_FAILURE(
-    ITC_Id_split(NULL, &pt_DummyId), ITC_STATUS_INVALID_PARAM);
-  TEST_FAILURE(
-    ITC_Id_split(&pt_DummyId, NULL), ITC_STATUS_INVALID_PARAM);
+  TEST_FAILURE(ITC_Id_split(NULL, &pt_DummyId), ITC_STATUS_INVALID_PARAM);
+  TEST_FAILURE(ITC_Id_split(&pt_DummyId, NULL), ITC_STATUS_INVALID_PARAM);
 }
 
 /* Test splitting an ID fails with corrupt ID */
@@ -1133,20 +1131,18 @@ void ITC_Id_Test_sumIdFailInvalidParam(void)
 {
     ITC_Id_t *pt_Dummy = NULL;
 
-    TEST_FAILURE(
-        ITC_Id_sum(NULL, pt_Dummy, &pt_Dummy), ITC_STATUS_INVALID_PARAM);
-    TEST_FAILURE(
-        ITC_Id_sum(pt_Dummy, NULL, &pt_Dummy), ITC_STATUS_INVALID_PARAM);
-    TEST_FAILURE(
-        ITC_Id_sum(pt_Dummy, pt_Dummy, NULL), ITC_STATUS_INVALID_PARAM);
+    TEST_FAILURE(ITC_Id_sum(NULL, &pt_Dummy), ITC_STATUS_INVALID_PARAM);
+    TEST_FAILURE(ITC_Id_sum(&pt_Dummy, NULL), ITC_STATUS_INVALID_PARAM);
 }
 
 /* Test summing an ID fails with corrupt ID */
 void ITC_Id_Test_sumIdFailWithCorruptId(void)
 {
-    ITC_Id_t *pt_Id1;
-    ITC_Id_t *pt_Id2;
-    ITC_Id_t *pt_SumId;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
+
+    /* Construct the other ID */
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
 
     /* Test different invalid IDs are handled properly */
     for (uint32_t u32_I = 0;
@@ -1154,373 +1150,375 @@ void ITC_Id_Test_sumIdFailWithCorruptId(void)
          u32_I++)
     {
         /* Construct an invalid ID */
-        gpv_InvalidIdConstructorTable[u32_I](&pt_Id1);
-
-        /* Construct the other ID */
-        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id2, NULL));
+        gpv_InvalidIdConstructorTable[u32_I](&pt_Id);
 
         /* Test for the failure */
-        TEST_FAILURE(
-            ITC_Id_sum(pt_Id1, pt_Id2, &pt_SumId), ITC_STATUS_CORRUPT_ID);
+        TEST_FAILURE(ITC_Id_sum(&pt_Id, &pt_OtherId), ITC_STATUS_CORRUPT_ID);
         /* And the other way around */
-        TEST_FAILURE(
-            ITC_Id_sum(pt_Id2, pt_Id1, &pt_SumId), ITC_STATUS_CORRUPT_ID);
+        TEST_FAILURE(ITC_Id_sum(&pt_OtherId, &pt_Id), ITC_STATUS_CORRUPT_ID);
 
         /* Destroy the IDs */
-        gpv_InvalidIdDestructorTable[u32_I](&pt_Id1);
-        TEST_SUCCESS(ITC_Id_destroy(&pt_Id2));
+        gpv_InvalidIdDestructorTable[u32_I](&pt_Id);
     }
+
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test summing two seed IDs fails with overlapping ID interval */
 void ITC_Id_Test_sumId11FailOverlappingInterval(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
     /* Create two seed IDs */
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId2, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId1, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OtherId, NULL));
 
     /* Sum the IDs */
     TEST_FAILURE(
-        ITC_Id_sum(pt_OriginalId1, pt_OriginalId2, &pt_SumId),
+        ITC_Id_sum(&pt_Id, &pt_OtherId),
         ITC_STATUS_OVERLAPPING_ID_INTERVAL);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test summing two NULL IDs succeeds */
 void ITC_Id_Test_sumId00Succeeds(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
     /* Create two NULL IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
 
     /* Sum the IDs */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId1, pt_OriginalId2, &pt_SumId));
+    TEST_SUCCESS(ITC_Id_sum(&pt_Id, &pt_OtherId));
 
     /* Test the summed ID is a NULL ID */
-    TEST_ITC_ID_IS_NULL_ID(pt_SumId);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test summing two NULL ID subtrees succeeds */
 void ITC_Id_Test_sumId00SubtreesSucceeds(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* clang-format off */
-    /* Create two NULL IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1->pt_Left, pt_OriginalId1));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1->pt_Right, pt_OriginalId1));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Left, pt_OriginalId2));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Right, pt_OriginalId2));
-    /* clang-format on */
+    /* Create two NULL ID subtrees */
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Left, pt_OtherId));
+    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Right, pt_OtherId));
 
-    /* Sum the IDs */
-    TEST_SUCCESS(
-        ITC_Id_sum(
-            pt_OriginalId1->pt_Left,
-            pt_OriginalId2->pt_Right,
-            &pt_SumId));
+    /* Sum the ID subtrees */
+    TEST_SUCCESS(ITC_Id_sum(&pt_Id->pt_Left, &pt_OtherId->pt_Right));
 
     /* Test the summed ID is a NULL ID */
-    TEST_ITC_ID_IS_NULL_ID(pt_SumId);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
+
+    /* Test the rest of the ID hasn't changed */
+    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
 
     /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
 /* Test summing a NULL and a seed ID succeeds */
 void ITC_Id_Test_sumId01And10Succeeds(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* Create the NULL and seed IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId2, NULL));
+    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
+    {
+        /* Create the NULL and seed IDs */
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OtherId, NULL));
 
-    /* Sum the IDs */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId1, pt_OriginalId2, &pt_SumId));
+        if (u32_I)
+        {
+            /* Sum the IDs */
+            TEST_SUCCESS(ITC_Id_sum(&pt_Id, &pt_OtherId));
 
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_Id);
+        }
+        else
+        {
+            /* Sum the IDs the other way around */
+            TEST_SUCCESS(ITC_Id_sum(&pt_OtherId, &pt_Id));
 
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_OtherId);
+        }
 
-    /* Sum the IDs the other way around */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId2, pt_OriginalId1, &pt_SumId));
-
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+        /* Destroy the IDs */
+        TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+        TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
+    }
 }
 
 /* Test summing a NULL and a seed ID subtrees succeeds */
 void ITC_Id_Test_sumId01And10SubtreesSucceeds(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* clang-format off */
-    /* Create the NULL and seed IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1->pt_Left, pt_OriginalId1));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1->pt_Right, pt_OriginalId1));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Left, pt_OriginalId2));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId2->pt_Right, pt_OriginalId2));
-    /* clang-format on */
+    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
+    {
+        /* Create the NULL and seed IDs */
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Left, pt_OtherId));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OtherId->pt_Right, pt_OtherId));
 
-    /* Sum the IDs */
-    TEST_SUCCESS(
-        ITC_Id_sum(
-            pt_OriginalId1->pt_Left,
-            pt_OriginalId2->pt_Right,
-            &pt_SumId));
+        if (u32_I)
+        {
+            /* Sum the IDs */
+            TEST_SUCCESS(ITC_Id_sum(&pt_Id->pt_Left, &pt_OtherId->pt_Right));
 
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_Id->pt_Left);
 
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+            /* Test the rest of the ID hasn't changed */
+            TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
+            TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
+        }
+        else
+        {
+            /* Sum the IDs the other way around */
+            TEST_SUCCESS(ITC_Id_sum(&pt_OtherId->pt_Right, &pt_Id->pt_Left));
 
-    /* Sum the IDs the other way around */
-    TEST_SUCCESS(
-        ITC_Id_sum(
-            pt_OriginalId2->pt_Right,
-            pt_OriginalId1->pt_Left,
-            &pt_SumId));
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_OtherId->pt_Right);
 
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
+            /* Test the rest of the ID hasn't changed */
+            TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
+            TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
+        }
 
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+        /* Destroy the IDs */
+        TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+        TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
+    }
 }
 
 /* Test summing a NULL and a (0, 1) ID succeeds */
 void ITC_Id_Test_sumId001And010Succeeds(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* clang-format off */
-    /* Create the NULL and (0, 1) IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Left, pt_OriginalId2));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId2->pt_Right, pt_OriginalId2));
-    /* clang-format on */
+    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
+    {
+        /* Create the null and (0, 1) IDs */
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Left, pt_OtherId));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OtherId->pt_Right, pt_OtherId));
 
-    /* Sum the IDs */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId1, pt_OriginalId2, &pt_SumId));
+        if (u32_I)
+        {
+            /* Sum the IDs */
+            TEST_SUCCESS(ITC_Id_sum(&pt_Id, &pt_OtherId));
 
-    /* Test the summed ID is a (0, 1) ID */
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SumId);
+            /* Test the summed ID is a (0, 1) ID */
+            TEST_ITC_ID_IS_NULL_SEED_ID(pt_Id);
+        }
+        else
+        {
+            /* Sum the IDs the other way around */
+            TEST_SUCCESS(ITC_Id_sum(&pt_OtherId, &pt_Id));
 
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+            /* Test the summed ID is a (0, 1) ID */
+            TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId);
+        }
 
-    /* Sum the IDs the other way around */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId2, pt_OriginalId1, &pt_SumId));
-
-    /* Test the summed ID is a (0, 1) ID */
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_SumId);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+        /* Destroy the IDs */
+        TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+        TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
+    }
 }
 
 /* Test summing a NULL and a (1, 0) ID succeeds */
 void ITC_Id_Test_sumId010And100Succeeds(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* clang-format off */
-    /* Create the NULL and (1, 0) IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId2->pt_Left, pt_OriginalId2));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Right, pt_OriginalId2));
-    /* clang-format on */
+    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
+    {
+        /* Create the NULL and (1, 0) IDs */
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OtherId->pt_Left, pt_OtherId));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Right, pt_OtherId));
 
-    /* Sum the IDs */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId1, pt_OriginalId2, &pt_SumId));
+        if (u32_I)
+        {
+            /* Sum the IDs */
+            TEST_SUCCESS(ITC_Id_sum(&pt_Id, &pt_OtherId));
 
-    /* Test the summed ID is a (1, 0) ID */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SumId);
+            /* Test the summed ID is a (1, 0) ID */
+            TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id);
+        }
+        else
+        {
+            /* Sum the IDs the other way around */
+            TEST_SUCCESS(ITC_Id_sum(&pt_OtherId, &pt_Id));
 
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+            /* Test the summed ID is a (1, 0) ID */
+            TEST_ITC_ID_IS_SEED_NULL_ID(pt_OtherId);
+        }
 
-    /* Sum the IDs the other way around */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId2, pt_OriginalId1, &pt_SumId));
-
-    /* Test the summed ID is a (1, 0) ID */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SumId);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+        /* Destroy the IDs */
+        TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+        TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
+    }
 }
 
 /* Test summing a (1, 0) and a (0, 1) ID succeeds */
 void ITC_Id_Test_sumId1001And0110Succeeds(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* clang-format off */
-    /* Create the (1, 0) and (0, 1) IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId1->pt_Left, pt_OriginalId1));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1->pt_Right, pt_OriginalId1));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Left, pt_OriginalId2));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId2->pt_Right, pt_OriginalId2));
-    /* clang-format on */
+    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
+    {
+        /* Create the (1, 0) and (0, 1) IDs */
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left, pt_Id));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Left, pt_OtherId));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OtherId->pt_Right, pt_OtherId));
 
-    /* Sum the IDs */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId1, pt_OriginalId2, &pt_SumId));
+        if (u32_I)
+        {
+            /* Sum the IDs */
+            TEST_SUCCESS(ITC_Id_sum(&pt_Id, &pt_OtherId));
 
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_Id);
+        }
+        else
+        {
+            /* Sum the IDs the other way around */
+            TEST_SUCCESS(ITC_Id_sum(&pt_OtherId, &pt_Id));
 
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_OtherId);
+        }
 
-    /* Sum the IDs the other way around */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId2, pt_OriginalId1, &pt_SumId));
-
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+        /* Destroy the IDs */
+        TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+        TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
+    }
 }
 
 /* Test summing a ((1, 0), 1) and a ((0, 1), 0) ID succeeds */
 void ITC_Id_Test_sumId110001And001110Succeeds(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* clang-format off */
-    /* Create the (1, 0), 1) and a ((0, 1), 0) IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1->pt_Left, pt_OriginalId1));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId1->pt_Left->pt_Left, pt_OriginalId1->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1->pt_Left->pt_Right, pt_OriginalId1->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId1->pt_Right, pt_OriginalId1));
+    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
+    {
+        /* clang-format off */
+        /* Create the (1, 0), 1) and a ((0, 1), 0) IDs */
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left->pt_Left, pt_Id->pt_Left));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right, pt_Id->pt_Left));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right, pt_Id));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Left, pt_OriginalId2));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Left->pt_Left, pt_OriginalId2->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId2->pt_Left->pt_Right, pt_OriginalId2->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Right, pt_OriginalId2));
-    /* clang-format on */
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Left, pt_OtherId));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Left->pt_Left, pt_OtherId->pt_Left));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OtherId->pt_Left->pt_Right, pt_OtherId->pt_Left));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Right, pt_OtherId));
+        /* clang-format on */
 
-    /* Sum the IDs */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId1, pt_OriginalId2, &pt_SumId));
+        if (u32_I)
+        {
+            /* Sum the IDs */
+            TEST_SUCCESS(ITC_Id_sum(&pt_Id, &pt_OtherId));
 
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_Id);
+        }
+        else
+        {
+            /* Sum the IDs the other way around */
+            TEST_SUCCESS(ITC_Id_sum(&pt_OtherId, &pt_Id));
 
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_OtherId);
+        }
 
-    /* Sum the IDs the other way around */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId2, pt_OriginalId1, &pt_SumId));
-
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+        /* Destroy the IDs */
+        TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+        TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
+    }
 }
 
 /* Test summing a (1, (1, 0)) and a (0, (0, 1)) ID succeeds */
 void ITC_Id_Test_sumId001110And110001Succeeds(void)
 {
-    ITC_Id_t *pt_OriginalId1;
-    ITC_Id_t *pt_OriginalId2;
-    ITC_Id_t *pt_SumId = NULL;
+    ITC_Id_t *pt_Id;
+    ITC_Id_t *pt_OtherId;
 
-    /* clang-format off */
-    /* Create the (1, (1, 0)) and a (0, (0, 1)) IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId1->pt_Left, pt_OriginalId1));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1->pt_Right, pt_OriginalId1));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId1->pt_Right->pt_Left, pt_OriginalId1->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId1->pt_Right->pt_Right, pt_OriginalId1->pt_Right));
+    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
+    {
+        /* clang-format off */
+        /* Create the (1, (1, 0)) and a (0, (0, 1)) IDs */
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left, pt_Id));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Left, pt_Id->pt_Right));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Right, pt_Id->pt_Right));
 
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Left, pt_OriginalId2));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Right, pt_OriginalId2));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId2->pt_Right->pt_Left, pt_OriginalId2->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId2->pt_Right->pt_Right, pt_OriginalId2->pt_Right));
-    /* clang-format on */
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Left, pt_OtherId));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Right, pt_OtherId));
+        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Right->pt_Left, pt_OtherId->pt_Right));
+        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OtherId->pt_Right->pt_Right, pt_OtherId->pt_Right));
+        /* clang-format on */
 
-    /* Sum the IDs */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId1, pt_OriginalId2, &pt_SumId));
+        if (u32_I)
+        {
+            /* Sum the IDs */
+            TEST_SUCCESS(ITC_Id_sum(&pt_Id, &pt_OtherId));
 
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_Id);
+        }
+        else
+        {
+            /* Sum the IDs the other way around */
+            TEST_SUCCESS(ITC_Id_sum(&pt_OtherId, &pt_Id));
 
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+            /* Test the summed ID is a seed ID */
+            TEST_ITC_ID_IS_SEED_ID(pt_OtherId);
+        }
 
-    /* Sum the IDs the other way around */
-    TEST_SUCCESS(ITC_Id_sum(pt_OriginalId2, pt_OriginalId1, &pt_SumId));
-
-    /* Test the summed ID is a seed ID */
-    TEST_ITC_ID_IS_SEED_ID(pt_SumId);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SumId));
+        /* Destroy the IDs */
+        TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+        TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
+    }
 }
 
 /* Test splitting a seed ID several times and summing it back succeeds */
@@ -1534,9 +1532,6 @@ void ITC_Id_Test_sumIdSplitSeedAndSumItBackToSeedSucceeds(void)
     ITC_Id_t *pt_Id5;
     ITC_Id_t *pt_Id6;
     ITC_Id_t *pt_Id7;
-
-    ITC_Id_t *pt_SummedId = NULL;
-    ITC_Id_t *pt_TmpId = NULL;
 
     /* Create the seed ID */
     TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id0, NULL));
@@ -1561,55 +1556,15 @@ void ITC_Id_Test_sumIdSplitSeedAndSumItBackToSeedSucceeds(void)
     TEST_SUCCESS(ITC_Id_split(&pt_Id4, &pt_Id5));
     TEST_SUCCESS(ITC_Id_split(&pt_Id6, &pt_Id7));
 
-    /* Sum them back into to a seed in arbitrary order */
+    /* Sum them back into a seed in arbitrary order */
+    TEST_SUCCESS(ITC_Id_sum(&pt_Id7, &pt_Id3));
+    TEST_SUCCESS(ITC_Id_sum(&pt_Id7, &pt_Id1));
+    TEST_SUCCESS(ITC_Id_sum(&pt_Id7, &pt_Id4));
+    TEST_SUCCESS(ITC_Id_sum(&pt_Id7, &pt_Id6));
+    TEST_SUCCESS(ITC_Id_sum(&pt_Id7, &pt_Id2));
+    TEST_SUCCESS(ITC_Id_sum(&pt_Id7, &pt_Id0));
+    TEST_SUCCESS(ITC_Id_sum(&pt_Id7, &pt_Id5));
 
-    TEST_SUCCESS(ITC_Id_sum(pt_Id0, pt_Id3, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id0));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id3));
-
-    TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
-
-    TEST_SUCCESS(ITC_Id_sum(pt_Id5, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id5));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
-
-    TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
-
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
-
-    TEST_SUCCESS(ITC_Id_sum(pt_Id7, pt_TmpId, &pt_SummedId));
+    TEST_ITC_ID_IS_SEED_ID(pt_Id7);
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id7));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
-
-    TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
-
-    TEST_SUCCESS(ITC_Id_sum(pt_Id6, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id6));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
-
-    TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
-
-    TEST_SUCCESS(ITC_Id_sum(pt_Id2, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id2));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
-
-    TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
-
-    TEST_SUCCESS(ITC_Id_sum(pt_Id4, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id4));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
-
-    TEST_SUCCESS(ITC_Id_clone(pt_SummedId, &pt_TmpId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
-
-    TEST_SUCCESS(ITC_Id_sum(pt_Id1, pt_TmpId, &pt_SummedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id1));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_TmpId));
-
-    TEST_ITC_ID_IS_SEED_ID(pt_SummedId);
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SummedId));
 }

--- a/libitc/test/normal/ITC_Stamp_Test.c
+++ b/libitc/test/normal/ITC_Stamp_Test.c
@@ -288,19 +288,16 @@ void ITC_Stamp_Test_forkStampFailInvalidParam(void)
     ITC_Stamp_t *pt_DummyStamp = NULL;
 
     TEST_FAILURE(
-        ITC_Stamp_fork(pt_DummyStamp, NULL, NULL), ITC_STATUS_INVALID_PARAM);
+        ITC_Stamp_fork(&pt_DummyStamp, NULL), ITC_STATUS_INVALID_PARAM);
     TEST_FAILURE(
-        ITC_Stamp_fork(NULL, &pt_DummyStamp, NULL), ITC_STATUS_INVALID_PARAM);
-    TEST_FAILURE(
-        ITC_Stamp_fork(NULL, NULL, &pt_DummyStamp), ITC_STATUS_INVALID_PARAM);
+        ITC_Stamp_fork(NULL, &pt_DummyStamp), ITC_STATUS_INVALID_PARAM);
 }
 
 /* Test forking a Stamp fails with corrupt stamp */
 void ITC_Stamp_Test_forkStampFailWithCorruptStamp(void)
 {
     ITC_Stamp_t *pt_Stamp;
-    ITC_Stamp_t *pt_ForkedStamp1;
-    ITC_Stamp_t *pt_ForkedStamp2;
+    ITC_Stamp_t *pt_OtherStamp;
 
     /* Test different invalid Stamps are handled properly */
     for (uint32_t u32_I = 0;
@@ -312,7 +309,7 @@ void ITC_Stamp_Test_forkStampFailWithCorruptStamp(void)
 
         /* Test for the failure */
         TEST_FAILURE(
-            ITC_Stamp_fork(pt_Stamp, &pt_ForkedStamp1, &pt_ForkedStamp2),
+            ITC_Stamp_fork(&pt_Stamp, &pt_OtherStamp),
             ITC_STATUS_CORRUPT_STAMP);
 
         /* Destroy the Stamp */
@@ -324,8 +321,7 @@ void ITC_Stamp_Test_forkStampFailWithCorruptStamp(void)
 void ITC_Stamp_Test_forkStampFailWithCorruptIdOrEvent(void)
 {
     ITC_Stamp_t *pt_Stamp;
-    ITC_Stamp_t *pt_ForkedStamp1;
-    ITC_Stamp_t *pt_ForkedStamp2;
+    ITC_Stamp_t *pt_OtherStamp;
 
     /* Create a new stamp */
     TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Stamp));
@@ -343,7 +339,7 @@ void ITC_Stamp_Test_forkStampFailWithCorruptIdOrEvent(void)
 
         /* Test for the failure */
         TEST_FAILURE(
-            ITC_Stamp_fork(pt_Stamp, &pt_ForkedStamp1, &pt_ForkedStamp2),
+            ITC_Stamp_fork(&pt_Stamp, &pt_OtherStamp),
             ITC_STATUS_CORRUPT_ID);
 
         /* Destroy the ID */
@@ -366,7 +362,7 @@ void ITC_Stamp_Test_forkStampFailWithCorruptIdOrEvent(void)
 
         /* Test for the failure */
         TEST_FAILURE(
-            ITC_Stamp_fork(pt_Stamp, &pt_ForkedStamp1, &pt_ForkedStamp2),
+            ITC_Stamp_fork(&pt_Stamp, &pt_OtherStamp),
             ITC_STATUS_CORRUPT_EVENT);
 
         /* Destroy the Event */
@@ -380,30 +376,25 @@ void ITC_Stamp_Test_forkStampFailWithCorruptIdOrEvent(void)
 /* Test forking a Stamp succeeds */
 void ITC_Stamp_Test_forkStampSuccessful(void)
 {
-    ITC_Stamp_t *pt_OriginalStamp;
-    ITC_Stamp_t *pt_ForkedStamp1;
-    ITC_Stamp_t *pt_ForkedStamp2;
+    ITC_Stamp_t *pt_Stamp;
+    ITC_Stamp_t *pt_OtherStamp;
 
     /* Create a new Stamp */
-    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_OriginalStamp));
+    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Stamp));
 
     /* Fork the Stamp */
-    TEST_SUCCESS(
-        ITC_Stamp_fork(pt_OriginalStamp, &pt_ForkedStamp1, &pt_ForkedStamp2));
-
-    /* Destroy the original Stamp */
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_OriginalStamp));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp, &pt_OtherStamp));
 
     /* Test the ID was cloned and split and the Event history was cloned */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_ForkedStamp1->pt_Id);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_ForkedStamp2->pt_Id);
-    TEST_ASSERT_TRUE(pt_ForkedStamp1->pt_Event != pt_ForkedStamp2->pt_Event);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_ForkedStamp1->pt_Event, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_ForkedStamp2->pt_Event, 0);
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Stamp->pt_Id);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherStamp->pt_Id);
+    TEST_ASSERT_TRUE(pt_Stamp->pt_Event != pt_OtherStamp->pt_Event);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp->pt_Event, 0);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherStamp->pt_Event, 0);
 
     /* Destroy the forked Stamps */
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_ForkedStamp1));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_ForkedStamp2));
+    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp));
+    TEST_SUCCESS(ITC_Stamp_destroy(&pt_OtherStamp));
 }
 
 /* Test joining two Stamps fails with invalid param */
@@ -412,22 +403,19 @@ void ITC_Stamp_Test_joinStampsFailInvalidParam(void)
     ITC_Stamp_t *pt_DummyStamp = NULL;
 
     TEST_FAILURE(
-        ITC_Stamp_join(pt_DummyStamp, NULL, NULL), ITC_STATUS_INVALID_PARAM);
+        ITC_Stamp_join(&pt_DummyStamp, NULL), ITC_STATUS_INVALID_PARAM);
     TEST_FAILURE(
-        ITC_Stamp_join(NULL, pt_DummyStamp, NULL), ITC_STATUS_INVALID_PARAM);
-    TEST_FAILURE(
-        ITC_Stamp_join(NULL, NULL, &pt_DummyStamp), ITC_STATUS_INVALID_PARAM);
+        ITC_Stamp_join(NULL, &pt_DummyStamp), ITC_STATUS_INVALID_PARAM);
 }
 
 /* Test joining two Stamps fails with corrupt stamp */
 void ITC_Stamp_Test_joinStampsFailWithCorruptStamp(void)
 {
-    ITC_Stamp_t *pt_Stamp1;
-    ITC_Stamp_t *pt_Stamp2;
-    ITC_Stamp_t *pt_JoinedStamp;
+    ITC_Stamp_t *pt_Stamp;
+    ITC_Stamp_t *pt_OtherStamp;
 
     /* Construct the other Stamp */
-    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Stamp2));
+    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_OtherStamp));
 
     /* Test different invalid Stamps are handled properly */
     for (uint32_t u32_I = 0;
@@ -435,38 +423,37 @@ void ITC_Stamp_Test_joinStampsFailWithCorruptStamp(void)
          u32_I++)
     {
         /* Construct an invalid Stamp */
-        gpv_InvalidStampConstructorTable[u32_I](&pt_Stamp1);
+        gpv_InvalidStampConstructorTable[u32_I](&pt_Stamp);
 
         /* Test for the failure */
         TEST_FAILURE(
-            ITC_Stamp_join(pt_Stamp1, pt_Stamp2, &pt_JoinedStamp),
+            ITC_Stamp_join(&pt_Stamp, &pt_OtherStamp),
             ITC_STATUS_CORRUPT_STAMP);
         /* And the other way around */
         TEST_FAILURE(
-            ITC_Stamp_join(pt_Stamp2, pt_Stamp1, &pt_JoinedStamp),
+            ITC_Stamp_join(&pt_OtherStamp, &pt_Stamp),
             ITC_STATUS_CORRUPT_STAMP);
 
         /* Destroy the Stamp */
-        gpv_InvalidStampDestructorTable[u32_I](&pt_Stamp1);
+        gpv_InvalidStampDestructorTable[u32_I](&pt_Stamp);
     }
 
     /* Destroy the other Stamp */
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp2));
+    TEST_SUCCESS(ITC_Stamp_destroy(&pt_OtherStamp));
 }
 
 /* Test joining a Stamp fails with corrupt Id or Event */
 void ITC_Stamp_Test_joinStampFailWithCorruptIdOrEvent(void)
 {
-    ITC_Stamp_t *pt_Stamp1;
-    ITC_Stamp_t *pt_Stamp2;
-    ITC_Stamp_t *pt_JoinedStamp;
+    ITC_Stamp_t *pt_Stamp;
+    ITC_Stamp_t *pt_OtherStamp;
 
     /* Create new Stamps */
-    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Stamp1));
-    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Stamp2));
+    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Stamp));
+    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_OtherStamp));
 
     /* Deallocate the valid ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Stamp1->pt_Id));
+    TEST_SUCCESS(ITC_Id_destroy(&pt_Stamp->pt_Id));
 
     /* Test different invalid IDs are handled properly */
     for (uint32_t u32_I = 0;
@@ -474,26 +461,26 @@ void ITC_Stamp_Test_joinStampFailWithCorruptIdOrEvent(void)
          u32_I++)
     {
         /* Construct an invalid ID */
-        gpv_InvalidIdConstructorTable[u32_I](&pt_Stamp1->pt_Id);
+        gpv_InvalidIdConstructorTable[u32_I](&pt_Stamp->pt_Id);
 
         /* Test for the failure */
         TEST_FAILURE(
-            ITC_Stamp_join(pt_Stamp1, pt_Stamp2, &pt_JoinedStamp),
+            ITC_Stamp_join(&pt_Stamp, &pt_OtherStamp),
             ITC_STATUS_CORRUPT_ID);
         /* Test the other way around */
         TEST_FAILURE(
-            ITC_Stamp_join(pt_Stamp2, pt_Stamp1, &pt_JoinedStamp),
+            ITC_Stamp_join(&pt_OtherStamp, &pt_Stamp),
             ITC_STATUS_CORRUPT_ID);
 
         /* Destroy the ID */
-        gpv_InvalidIdDestructorTable[u32_I](&pt_Stamp1->pt_Id);
+        gpv_InvalidIdDestructorTable[u32_I](&pt_Stamp->pt_Id);
     }
 
     /* Allocate a valid ID */
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Stamp1->pt_Id, NULL));
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Stamp->pt_Id, NULL));
 
     /* Deallocate the valid Event */
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Stamp1->pt_Event));
+    TEST_SUCCESS(ITC_Event_destroy(&pt_Stamp->pt_Event));
 
     /* Test different invalid Events are handled properly */
     for (uint32_t u32_I = 0;
@@ -501,57 +488,47 @@ void ITC_Stamp_Test_joinStampFailWithCorruptIdOrEvent(void)
          u32_I++)
     {
         /* Construct an invalid Event */
-        gpv_InvalidEventConstructorTable[u32_I](&pt_Stamp1->pt_Event);
+        gpv_InvalidEventConstructorTable[u32_I](&pt_Stamp->pt_Event);
 
         /* Test for the failure */
         TEST_FAILURE(
-            ITC_Stamp_join(pt_Stamp1, pt_Stamp2, &pt_JoinedStamp),
+            ITC_Stamp_join(&pt_Stamp, &pt_OtherStamp),
             ITC_STATUS_CORRUPT_EVENT);
         /* Test the other way around */
         TEST_FAILURE(
-            ITC_Stamp_join(pt_Stamp2, pt_Stamp1, &pt_JoinedStamp),
+            ITC_Stamp_join(&pt_OtherStamp, &pt_Stamp),
             ITC_STATUS_CORRUPT_EVENT);
 
         /* Destroy the Event */
-        gpv_InvalidEventDestructorTable[u32_I](&pt_Stamp1->pt_Event);
+        gpv_InvalidEventDestructorTable[u32_I](&pt_Stamp->pt_Event);
     }
 
     /* Deallocate the Stamps */
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp1));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp2));
+    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp));
+    TEST_SUCCESS(ITC_Stamp_destroy(&pt_OtherStamp));
 }
 
 /* Test joining two Stamps succeeds */
 void ITC_Stamp_Test_joinStampsSuccessful(void)
 {
     ITC_Stamp_t *pt_Stamp;
-    ITC_Stamp_t *pt_ForkedStamp1;
-    ITC_Stamp_t *pt_ForkedStamp2;
+    ITC_Stamp_t *pt_OtherStamp;
 
     /* Create a new Stamp */
     TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Stamp));
 
     /* Fork the Stamp */
-    TEST_SUCCESS(
-        ITC_Stamp_fork(pt_Stamp, &pt_ForkedStamp1, &pt_ForkedStamp2));
-
-    /* Destroy the original Stamp */
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp, &pt_OtherStamp));
 
     /* Join the Stamps */
-    TEST_SUCCESS(
-        ITC_Stamp_join(pt_ForkedStamp1, pt_ForkedStamp2, &pt_Stamp));
-
-    /* Destroy the forked Stamps */
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_ForkedStamp1));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_ForkedStamp2));
+    TEST_SUCCESS(ITC_Stamp_join(&pt_OtherStamp, &pt_Stamp));
 
     /* Test the ID is a seed ID and the Event history is a leaf with 0 events */
-    TEST_ITC_ID_IS_SEED_ID(pt_Stamp->pt_Id);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp->pt_Event, 0);
+    TEST_ITC_ID_IS_SEED_ID(pt_OtherStamp->pt_Id);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherStamp->pt_Event, 0);
 
     /* Destroy the original Stamp */
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp));
+    TEST_SUCCESS(ITC_Stamp_destroy(&pt_OtherStamp));
 }
 
 /* Test inflating the Event of as Stamp fails with invalid param */
@@ -868,289 +845,189 @@ void ITC_Stamp_Test_compareStampsSucceeds(void)
 /* Test full Stamp lifecycle */
 void ITC_Stamp_Test_fullStampLifecycle(void)
 {
-    ITC_Stamp_t *pt_OriginalStamp;
-    ITC_Stamp_t *pt_SplitStamp1;
-    ITC_Stamp_t *pt_SplitStamp11;
-    ITC_Stamp_t *pt_SplitStamp12;
-    ITC_Stamp_t *pt_SplitStamp111;
-    ITC_Stamp_t *pt_SplitStamp121;
-    ITC_Stamp_t *pt_SplitStamp112;
-    ITC_Stamp_t *pt_SplitStamp122;
-    ITC_Stamp_t *pt_SplitStamp2;
-    ITC_Stamp_t *pt_SplitStamp21;
-    ITC_Stamp_t *pt_SplitStamp22;
-    ITC_Stamp_t *pt_SplitStamp211;
-    ITC_Stamp_t *pt_SplitStamp221;
-    ITC_Stamp_t *pt_SplitStamp212;
-    ITC_Stamp_t *pt_SplitStamp222;
+    ITC_Stamp_t *pt_Stamp0 = NULL;
+    ITC_Stamp_t *pt_Stamp1 = NULL;
+    ITC_Stamp_t *pt_Stamp2 = NULL;
+    ITC_Stamp_t *pt_Stamp3 = NULL;
+    ITC_Stamp_t *pt_Stamp4 = NULL;
+    ITC_Stamp_t *pt_Stamp5 = NULL;
+    ITC_Stamp_t *pt_Stamp6 = NULL;
+    ITC_Stamp_t *pt_Stamp7 = NULL;
 
-    ITC_Stamp_t *pt_SummedStamp = NULL;
-    ITC_Stamp_t *pt_TmpStamp = NULL;
+    /* clang-format off */
+    /* Each pair corresponds to the call arg order of `ITC_Stamp_join`.
+     * The join order is arbitrary */
+    ITC_Stamp_t **rppt_JoinOrder[] = {
+        &pt_Stamp1, &pt_Stamp2,
+        &pt_Stamp1, &pt_Stamp5,
+        &pt_Stamp6, &pt_Stamp3,
+        &pt_Stamp1, &pt_Stamp6,
+        &pt_Stamp0, &pt_Stamp1,
+        &pt_Stamp4, &pt_Stamp7,
+        &pt_Stamp0, &pt_Stamp4,
+    };
+    /* clang-format on */
+
+    ITC_Stamp_t *pt_TmpStamp1;
+    ITC_Stamp_t *pt_TmpStamp2;
 
     ITC_Stamp_Comparison_t t_Result;
 
     /* Create the initial stamp */
-    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_OriginalStamp));
+    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Stamp0));
 
     /* Split into Stamps with (1, 0) and (0, 1) IDs */
-    TEST_SUCCESS(
-        ITC_Stamp_fork(pt_OriginalStamp, &pt_SplitStamp1, &pt_SplitStamp2));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_OriginalStamp));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp0, &pt_Stamp4));
 
     /* Add some events */
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp1));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp1));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp2));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp0));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp0));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp4));
 
     /* Test stamp ordering */
-    TEST_SUCCESS(ITC_Stamp_compare(pt_SplitStamp1, pt_SplitStamp2, &t_Result));
+    TEST_SUCCESS(ITC_Stamp_compare(pt_Stamp0, pt_Stamp4, &t_Result));
     TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_CONCURRENT, t_Result);
 
     /* Split into Stamps with IDs:
-     * - ((1, 0), 0)
-     * - (0, (1, 0))
-     * - ((0, 1), 0)
-     * - (0, (0, 1))
+     * pt_Stamp0 = ((1, 0), 0)
+     * pt_Stamp2 = ((0, 1), 0)
+     * pt_Stamp4 = (0, (1, 0))
+     * pt_Stamp6 = (0, (0, 1))
      */
-    TEST_SUCCESS(
-        ITC_Stamp_fork(pt_SplitStamp1, &pt_SplitStamp11, &pt_SplitStamp21));
-    TEST_SUCCESS(
-        ITC_Stamp_fork(pt_SplitStamp2, &pt_SplitStamp12, &pt_SplitStamp22));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp1));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp2));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp0, &pt_Stamp2));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp4, &pt_Stamp6));
 
     /* Add some events */
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp11));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp22));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp2));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp6));
 
     /* Test stamp ordering */
-    TEST_SUCCESS(ITC_Stamp_compare(pt_SplitStamp11, pt_SplitStamp22, &t_Result));
+    TEST_SUCCESS(ITC_Stamp_compare(pt_Stamp2, pt_Stamp6, &t_Result));
     TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_CONCURRENT, t_Result);
-    TEST_SUCCESS(ITC_Stamp_compare(pt_SplitStamp11, pt_SplitStamp21, &t_Result));
+    TEST_SUCCESS(ITC_Stamp_compare(pt_Stamp2, pt_Stamp0, &t_Result));
     TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-    TEST_SUCCESS(ITC_Stamp_compare(pt_SplitStamp12, pt_SplitStamp22, &t_Result));
+    TEST_SUCCESS(ITC_Stamp_compare(pt_Stamp4, pt_Stamp6, &t_Result));
     TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_LESS_THAN, t_Result);
-    TEST_SUCCESS(ITC_Stamp_compare(pt_SplitStamp12, pt_SplitStamp21, &t_Result));
+    TEST_SUCCESS(ITC_Stamp_compare(pt_Stamp0, pt_Stamp4, &t_Result));
     TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_CONCURRENT, t_Result);
 
     /* Split into Stamps with IDs:
-     * - (((1, 0), 0), 0)
-     * - (0, ((1, 0), 0))
-     * - ((0, (1, 0)), 0)
-     * - (0, (0, (1, 0)))
-     * - (((0, 1), 0), 0)
-     * - (0, ((0, 1), 0))
-     * - ((0, (0, 1)), 0)
-     * - (0, (0, (0, 1)))
+     * pt_Stamp0 = (((1, 0), 0), 0)
+     * pt_Stamp1 = (((0, 1), 0), 0)
+     * pt_Stamp2 = ((0, (1, 0)), 0)
+     * pt_Stamp3 = ((0, (0, 1)), 0)
+     * pt_Stamp4 = (0, ((1, 0), 0))
+     * pt_Stamp5 = (0, ((0, 1), 0))
+     * pt_Stamp6 = (0, (0, (1, 0)))
+     * pt_Stamp7 = (0, (0, (0, 1)))
      */
-    TEST_SUCCESS(ITC_Stamp_fork(
-        pt_SplitStamp11, &pt_SplitStamp111, &pt_SplitStamp211));
-    TEST_SUCCESS(ITC_Stamp_fork(
-        pt_SplitStamp12, &pt_SplitStamp112, &pt_SplitStamp212));
-    TEST_SUCCESS(ITC_Stamp_fork(
-        pt_SplitStamp21, &pt_SplitStamp121, &pt_SplitStamp221));
-    TEST_SUCCESS(ITC_Stamp_fork(
-        pt_SplitStamp22, &pt_SplitStamp122, &pt_SplitStamp222));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp11));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp12));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp21));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp22));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp0, &pt_Stamp1));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp2, &pt_Stamp3));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp4, &pt_Stamp5));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp6, &pt_Stamp7));
 
     /* Add some events */
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp211));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp212));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp222));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp222));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp122));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp111));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp1));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp3));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp5));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp6));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp7));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp7));
 
     /* Too lasy to test ordering here... It's probably fine (TM) */
 
     /* Sum them back into to a seed Stamp while adding events in
      * arbitrary order */
+    for (uint32_t u32_I = 0; u32_I < ARRAY_COUNT(rppt_JoinOrder); u32_I += 2)
+    {
+        /* Clone the Stamps for comparison */
+        TEST_SUCCESS(
+            ITC_Stamp_clone(*rppt_JoinOrder[u32_I], &pt_TmpStamp1));
+        TEST_SUCCESS(
+            ITC_Stamp_clone(*rppt_JoinOrder[u32_I + 1], &pt_TmpStamp2));
 
-    TEST_SUCCESS(ITC_Stamp_join(pt_SplitStamp222, pt_SplitStamp121, &pt_SummedStamp));
+        /* Join 2 Stamps */
+        TEST_SUCCESS(
+            ITC_Stamp_join(rppt_JoinOrder[u32_I], rppt_JoinOrder[u32_I + 1]));
 
-    /* Test the joined Stamp is greater than both of the source stamps */
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_SplitStamp222, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_SplitStamp121, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
+        /* Test the joined Stamp is greater-than or equal to both of the
+         * source stamps */
+        TEST_SUCCESS(
+            ITC_Stamp_compare(
+                *rppt_JoinOrder[u32_I],
+                pt_TmpStamp1,
+                &t_Result));
+        TEST_ASSERT_TRUE((t_Result == ITC_STAMP_COMPARISON_GREATER_THAN) ||
+                         (t_Result == ITC_STAMP_COMPARISON_EQUAL));
+        TEST_SUCCESS(
+            ITC_Stamp_compare(
+                *rppt_JoinOrder[u32_I],
+                pt_TmpStamp2,
+                &t_Result));
+        TEST_ASSERT_TRUE((t_Result == ITC_STAMP_COMPARISON_GREATER_THAN) ||
+                         (t_Result == ITC_STAMP_COMPARISON_EQUAL));
 
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp222));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp121));
+        TEST_SUCCESS(ITC_Stamp_destroy(&pt_TmpStamp1));
+        TEST_SUCCESS(ITC_Stamp_destroy(&pt_TmpStamp2));
 
-    /* Add some events */
-    TEST_SUCCESS(ITC_Stamp_event(pt_SummedStamp));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_clone(pt_SummedStamp, &pt_TmpStamp));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_join(pt_SplitStamp211, pt_TmpStamp, &pt_SummedStamp));
-
-    /* Test the joined Stamp is greater than both of the source stamps */
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_SplitStamp211, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_TmpStamp, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp211));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_TmpStamp));
-
-    /* Add some events */
-    TEST_SUCCESS(ITC_Stamp_event(pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_clone(pt_SummedStamp, &pt_TmpStamp));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_join(pt_SplitStamp122, pt_TmpStamp, &pt_SummedStamp));
-
-    /* Test the joined Stamp is greater than both of the source stamps */
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_SplitStamp122, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_TmpStamp, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp122));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_TmpStamp));
-
-    /* Add some events */
-    TEST_SUCCESS(ITC_Stamp_event(pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_clone(pt_SummedStamp, &pt_TmpStamp));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_join(pt_SplitStamp111, pt_TmpStamp, &pt_SummedStamp));
-
-    /* Test the joined Stamp is greater than both of the source stamps */
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_SplitStamp111, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_TmpStamp, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp111));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_TmpStamp));
-
-    TEST_SUCCESS(ITC_Stamp_clone(pt_SummedStamp, &pt_TmpStamp));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_join(pt_SplitStamp221, pt_TmpStamp, &pt_SummedStamp));
-
-    /* Test the joined Stamp is greater than or equal to both of the
-     * source stamps */
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_SplitStamp221, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_TmpStamp, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_EQUAL, t_Result);
-
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp221));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_TmpStamp));
-
-    /* Add some events */
-    TEST_SUCCESS(ITC_Stamp_event(pt_SummedStamp));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SummedStamp));
-    TEST_SUCCESS(ITC_Stamp_event(pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_clone(pt_SummedStamp, &pt_TmpStamp));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_join(pt_SplitStamp212, pt_TmpStamp, &pt_SummedStamp));
-
-    /* Test the joined Stamp is greater than both of the source stamps */
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_SplitStamp212, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_TmpStamp, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp212));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_TmpStamp));
-
-    TEST_SUCCESS(ITC_Stamp_clone(pt_SummedStamp, &pt_TmpStamp));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SummedStamp));
-
-    TEST_SUCCESS(ITC_Stamp_join(pt_SplitStamp112, pt_TmpStamp, &pt_SummedStamp));
-
-    /* Test the joined Stamp is greater than or equal to both of the
-     * source stamps */
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_SplitStamp112, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_GREATER_THAN, t_Result);
-    TEST_SUCCESS(
-        ITC_Stamp_compare(pt_SummedStamp, pt_TmpStamp, &t_Result));
-    TEST_ASSERT_EQUAL(ITC_STAMP_COMPARISON_EQUAL, t_Result);
-
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp112));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_TmpStamp));
+        /* Add Event on every second iteration but not the last one */
+        if ((u32_I % 4 == 0) && ((u32_I + 4) < ARRAY_COUNT(rppt_JoinOrder)))
+        {
+            TEST_SUCCESS(ITC_Stamp_event(*rppt_JoinOrder[u32_I]));
+        }
+    }
 
     /* clang-format off */
     /* Test the summed up Stamp has a seed ID with a
-     * (1, 3, (0, (0, 0, 1), 8)) Event tree */
-    TEST_ITC_ID_IS_SEED_ID(pt_SummedStamp->pt_Id);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_SummedStamp->pt_Event, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SummedStamp->pt_Event->pt_Left, 3);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_SummedStamp->pt_Event->pt_Right, 0);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_SummedStamp->pt_Event->pt_Right->pt_Left, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SummedStamp->pt_Event->pt_Right->pt_Left->pt_Left, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SummedStamp->pt_Event->pt_Right->pt_Left->pt_Right, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SummedStamp->pt_Event->pt_Right->pt_Right, 8);
+     * (1, 3, (0, (0, 0, 1), 3)) Event tree */
+    TEST_ITC_ID_IS_SEED_ID(pt_Stamp0->pt_Id);
+    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Stamp0->pt_Event, 1);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp0->pt_Event->pt_Left, 3);
+    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Stamp0->pt_Event->pt_Right, 0);
+    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Stamp0->pt_Event->pt_Right->pt_Left, 0);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp0->pt_Event->pt_Right->pt_Left->pt_Left, 0);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp0->pt_Event->pt_Right->pt_Left->pt_Right, 1);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp0->pt_Event->pt_Right->pt_Right, 3);
     /* clang-format on */
 
     /* Add an event */
-    TEST_SUCCESS(ITC_Stamp_event(pt_SummedStamp));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp0));
 
     /* Test the summed up Stamp has a seed ID with a
-     * (9) Event tree */
-    TEST_ITC_ID_IS_SEED_ID(pt_SummedStamp->pt_Id);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SummedStamp->pt_Event, 9);
+     * (4) Event tree */
+    TEST_ITC_ID_IS_SEED_ID(pt_Stamp0->pt_Id);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp0->pt_Event, 4);
 
     /* Split into Stamps with (1, 0) and (0, 1) IDs again */
-    TEST_SUCCESS(ITC_Stamp_fork(
-        pt_SummedStamp, &pt_SplitStamp1, &pt_SplitStamp2));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SummedStamp));
+    TEST_SUCCESS(ITC_Stamp_fork(&pt_Stamp0, &pt_Stamp1));
 
     /* Add Event */
-    TEST_SUCCESS(ITC_Stamp_event(pt_SplitStamp1));
+    TEST_SUCCESS(ITC_Stamp_event(pt_Stamp1));
 
-    /* Share the Event history */
-    TEST_SUCCESS(ITC_Stamp_newPeek(pt_SplitStamp1, &pt_SummedStamp));
-    TEST_SUCCESS(ITC_Stamp_join(pt_SummedStamp, pt_SplitStamp2, &pt_TmpStamp));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SummedStamp));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp2));
+    /* Share the Event history through a peek Stamp */
+    TEST_SUCCESS(ITC_Stamp_newPeek(pt_Stamp1, &pt_TmpStamp1));
+    TEST_SUCCESS(ITC_Stamp_join(&pt_Stamp0, &pt_TmpStamp1));
 
-    /* Test the Stamps have the different IDs but the same Event history */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_SplitStamp1->pt_Id);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_SplitStamp1->pt_Event, 9);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SplitStamp1->pt_Event->pt_Left, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SplitStamp1->pt_Event->pt_Right, 0);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_TmpStamp->pt_Id);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_TmpStamp->pt_Event, 9);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_TmpStamp->pt_Event->pt_Left, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_TmpStamp->pt_Event->pt_Right, 0);
+    /* Test the Stamp IDs haven't changed but the Event history has been shared */
+    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Stamp0->pt_Id);
+    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Stamp0->pt_Event, 4);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp0->pt_Event->pt_Left, 0);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp0->pt_Event->pt_Right, 1);
+    TEST_ITC_ID_IS_NULL_SEED_ID(pt_Stamp1->pt_Id);
+    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Stamp1->pt_Event, 4);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp1->pt_Event->pt_Left, 0);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp1->pt_Event->pt_Right, 1);
 
-    TEST_SUCCESS(ITC_Stamp_join(pt_SplitStamp1, pt_TmpStamp, &pt_SummedStamp));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SplitStamp1));
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_TmpStamp));
+    /* Join Stamps back into a Stamp with a seed ID */
+    TEST_SUCCESS(ITC_Stamp_join(&pt_Stamp0, &pt_Stamp1));
 
-    /* Test the Stamps has a seed ID but the same Event history */
-    TEST_ITC_ID_IS_SEED_ID(pt_SummedStamp->pt_Id);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_SummedStamp->pt_Event, 9);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SummedStamp->pt_Event->pt_Left, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_SummedStamp->pt_Event->pt_Right, 0);
+    /* Test the Stamp has a seed ID but the same Event history */
+    TEST_ITC_ID_IS_SEED_ID(pt_Stamp0->pt_Id);
+    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Stamp0->pt_Event, 4);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp0->pt_Event->pt_Left, 0);
+    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp0->pt_Event->pt_Right, 1);
 
-    TEST_SUCCESS(ITC_Stamp_destroy(&pt_SummedStamp));
+    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp0));
 }
 
 /* Test creating a Stamp from an ID fails with invalid param */


### PR DESCRIPTION
Changes the function signatures of `ITC_Event_join`, `ITC_Id_sum`, `ITC_Id_split`, `ITC_Stamp_fork` and `ITC_Stamp_join`. 

They will no longer treat the source ID/Event/Stamp as immutable. Instead the source will be deallocated and replaced with the output ID/Event/Stamp (where appropriate).

This change brings the following benefits:
* Reduces the developer burden. The developer will no longer be responsible for manually deallocating any source IDs/Events/Stamps.
* Makes it easier to perform these operations - i.e. wtihout having to use swap/tmp variables.
* Eliminates the possibility of accidentally continuing to use a previously joined/split ID/Stamp.

An effort is made to preserve the source ID/Event/Stamp state on failure. Still, it is not recommended to continue using one if a failure has occurred.