### PR TITLE
Add valgrind to CI

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -29,6 +29,9 @@ jobs:
           compiler: ${{ matrix.compiler }}
       - name: Install ninja and meson
         run: pip install ninja meson
+      - name: Install Valgrind
+        if: runner.os == 'Linux'
+        run: sudo apt install -y valgrind
       - name: Checkout
         uses: actions/checkout@v4
       - name: Configure Tests


### PR DESCRIPTION
Adds Valgrind to CI so that Meson can use it when executing unit tests.