### PR TITLE
Remove support for working with ID/Event subtrees

### DIFF
--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -47,19 +47,15 @@ static ITC_Status_t validateEvent(
     ITC_Status_t t_Status = ITC_STATUS_SUCCESS; /* The current status */
     /* The current Event parent */
     const ITC_Event_t *pt_CurrentEventParent = NULL;
-    /* The parent of the root Event */
-    const ITC_Event_t *pt_RootEventParent = NULL;
 
     if(!pt_Event)
     {
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
-    else
+    /* Subtrees are considered invalid when coming through the public API */
+    else if (pt_Event->pt_Parent)
     {
-        /* Remember the root parent Event as this might be a subtree */
-        pt_RootEventParent = pt_Event->pt_Parent;
-
-        pt_CurrentEventParent = pt_RootEventParent;
+        t_Status = ITC_STATUS_CORRUPT_EVENT;
     }
 
     /* Perform a pre-order traversal */
@@ -101,15 +97,15 @@ static ITC_Status_t validateEvent(
             {
                 /* Loop until the current element is no longer reachable
                  * through the parent's right child */
-                while (pt_CurrentEventParent != pt_RootEventParent &&
-                    pt_CurrentEventParent->pt_Right == pt_Event)
+                while (pt_CurrentEventParent &&
+                       pt_CurrentEventParent->pt_Right == pt_Event)
                 {
                     pt_Event = pt_Event->pt_Parent;
                     pt_CurrentEventParent = pt_CurrentEventParent->pt_Parent;
                 }
 
                 /* There is a right subtree that has not been explored yet */
-                if (pt_CurrentEventParent != pt_RootEventParent)
+                if (pt_CurrentEventParent)
                 {
                     pt_Event = pt_CurrentEventParent->pt_Right;
                 }

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -44,18 +44,15 @@ static ITC_Status_t validateId(
 {
     ITC_Status_t t_Status = ITC_STATUS_SUCCESS; /* The current status */
     const ITC_Id_t *pt_CurrentIdParent = NULL; /* The current ID node */
-    const ITC_Id_t *pt_RootIdParent = NULL; /* The parent of the root node */
 
     if(!pt_Id)
     {
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
-    else
+    /* Subtrees are considered invalid when coming through the public API */
+    else if (pt_Id->pt_Parent)
     {
-        /* Remember the root parent ID as this might be a subtree */
-        pt_RootIdParent = pt_Id->pt_Parent;
-
-        pt_CurrentIdParent = pt_RootIdParent;
+        t_Status = ITC_STATUS_CORRUPT_ID;
     }
 
     /* Perform a pre-order traversal */
@@ -96,15 +93,15 @@ static ITC_Status_t validateId(
             {
                 /* Loop until the current element is no longer reachable
                  * through the parent's right child */
-                while (pt_CurrentIdParent != pt_RootIdParent &&
-                    pt_CurrentIdParent->pt_Right == pt_Id)
+                while (pt_CurrentIdParent &&
+                       pt_CurrentIdParent->pt_Right == pt_Id)
                 {
                     pt_Id = pt_Id->pt_Parent;
                     pt_CurrentIdParent = pt_CurrentIdParent->pt_Parent;
                 }
 
                 /* There is a right subtree that has not been explored yet */
-                if (pt_CurrentIdParent != pt_RootIdParent)
+                if (pt_CurrentIdParent)
                 {
                     pt_Id = pt_CurrentIdParent->pt_Right;
                 }

--- a/libitc/test/ITC_TestUtil.c
+++ b/libitc/test/ITC_TestUtil.c
@@ -119,6 +119,34 @@ static void newInvalidIdWithAsymmetricNestedParentRight(
 }
 
 /**
+ * @brief Create a new invalid Id subtree
+ *
+ * @param pt_Id (out) The pointer to the Id
+ */
+static void newInvalidIdSubtree(
+    ITC_Id_t **ppt_Id
+)
+{
+    TEST_SUCCESS(ITC_TestUtil_newSeedId(ppt_Id, (ITC_Id_t *)123));
+}
+
+/**
+ * @brief Deallocate an invalid Id subtree created with
+ * `newInvalidIdSubtree`
+ *
+ *
+ * @param pt_Id (in) The pointer to the root of the Id.
+ */
+static void destroyInvalidIdSubtree(
+    ITC_Id_t **ppt_Id
+)
+{
+    /* Fix the damage so the Id can be properly deallocated */
+    (*ppt_Id)->pt_Parent = NULL;
+    TEST_SUCCESS(ITC_Id_destroy(ppt_Id));
+}
+
+/**
  * @brief Create a new invalid not normalised ID
  *
  * @param pt_Id (out) The pointer to the ID
@@ -175,7 +203,7 @@ static void newInvalidIdWithNullParentPointer(
  * `newInvalidIdWithNullParentPointer`
  *
  *
- * @param pt_Id (in) The pointer to the root if the ID.
+ * @param pt_Id (in) The pointer to the root of the ID.
  */
 static void destroyInvalidIdWithNullParentPointer(
     ITC_Id_t **ppt_Id
@@ -207,7 +235,7 @@ static void newInvalidIdWithInvalidParentPointer(
  * @brief Deallocate an invalid ID created with
  * `newInvalidIdWithInvalidParentPointer`
  *
- * @param pt_Id (in) The pointer to the root if the ID.
+ * @param pt_Id (in) The pointer to the root of the ID.
  */
 static void destroyInvalidIdWithInvalidParentPointer(
     ITC_Id_t **ppt_Id
@@ -535,7 +563,7 @@ static void newInvalidEventSubtree(
  * `newInvalidEventSubtree`
  *
  *
- * @param pt_Event (in) The pointer to the root if the Event.
+ * @param pt_Event (in) The pointer to the root of the Event.
  */
 static void destroyInvalidEventSubtree(
     ITC_Event_t **ppt_Event
@@ -606,7 +634,7 @@ static void newInvalidEventWithNullParentPointer(
  * `newInvalidEventWithNullParentPointer`
  *
  *
- * @param pt_Event (in) The pointer to the root if the Event.
+ * @param pt_Event (in) The pointer to the root of the Event.
  */
 static void destroyInvalidEventWithNullParentPointer(
     ITC_Event_t **ppt_Event
@@ -642,7 +670,7 @@ static void newInvalidEventWithInvalidParentPointer(
  * @brief Deallocate an invalid Event created with
  * `newInvalidEventWithInvalidParentPointer`
  *
- * @param pt_Event (in) The pointer to the root if the Event.
+ * @param pt_Event (in) The pointer to the root of the Event.
  */
 static void destroyInvalidEventWithInvalidParentPointer(
     ITC_Event_t **ppt_Event
@@ -1240,6 +1268,7 @@ void (*const gpv_InvalidIdConstructorTable[])(ITC_Id_t **) =
     newInvalidIdWithAsymmetricRootParentRight,
     newInvalidIdWithAsymmetricNestedParentLeft,
     newInvalidIdWithAsymmetricNestedParentRight,
+    newInvalidIdSubtree,
     newInvalidIdWithRootParentOwner,
     newInvalidIdWithNestedParentOwner,
     newInvalidIdWithNullParentPointer,
@@ -1264,6 +1293,7 @@ void (*const gpv_InvalidIdDestructorTable[])(ITC_Id_t **) =
     (void (*)(ITC_Id_t **))ITC_Id_destroy,
     (void (*)(ITC_Id_t **))ITC_Id_destroy,
     (void (*)(ITC_Id_t **))ITC_Id_destroy,
+    destroyInvalidIdSubtree,
     (void (*)(ITC_Id_t **))ITC_Id_destroy,
     (void (*)(ITC_Id_t **))ITC_Id_destroy,
     destroyInvalidIdWithNullParentPointer,

--- a/libitc/test/ITC_TestUtil.c
+++ b/libitc/test/ITC_TestUtil.c
@@ -519,6 +519,34 @@ static void newInvalidEventWithAsymmetricNestedParentRight(
 }
 
 /**
+ * @brief Create a new invalid Event subtree
+ *
+ * @param pt_Event (out) The pointer to the Event
+ */
+static void newInvalidEventSubtree(
+    ITC_Event_t **ppt_Event
+)
+{
+    TEST_SUCCESS(ITC_TestUtil_newEvent(ppt_Event, (ITC_Event_t *)123, 0));
+}
+
+/**
+ * @brief Deallocate an invalid Event subtree created with
+ * `newInvalidEventSubtree`
+ *
+ *
+ * @param pt_Event (in) The pointer to the root if the Event.
+ */
+static void destroyInvalidEventSubtree(
+    ITC_Event_t **ppt_Event
+)
+{
+    /* Fix the damage so the Event can be properly deallocated */
+    (*ppt_Event)->pt_Parent = NULL;
+    TEST_SUCCESS(ITC_Event_destroy(ppt_Event));
+}
+
+/**
  * @brief Create a new invalid not normalised Event
  *
  * @param pt_Event (out) The pointer to the Event
@@ -1290,6 +1318,7 @@ void (*const gpv_InvalidEventConstructorTable[])(ITC_Event_t **) =
     newInvalidEventWithAsymmetricRootParentRight,
     newInvalidEventWithAsymmetricNestedParentLeft,
     newInvalidEventWithAsymmetricNestedParentRight,
+    newInvalidEventSubtree,
     newInvalidEventWithNullParentPointer,
     newInvalidEventWithInvalidParentPointer,
     /* Normalisation related invalid Events.
@@ -1313,6 +1342,7 @@ void (*const gpv_InvalidEventDestructorTable[])(ITC_Event_t **) =
     (void (*)(ITC_Event_t **))ITC_Event_destroy,
     (void (*)(ITC_Event_t **))ITC_Event_destroy,
     (void (*)(ITC_Event_t **))ITC_Event_destroy,
+    destroyInvalidEventSubtree,
     destroyInvalidEventWithNullParentPointer,
     destroyInvalidEventWithInvalidParentPointer,
     /* Normalisation related invalid Events.

--- a/libitc/test/include/ITC_TestUtil.h
+++ b/libitc/test/include/ITC_TestUtil.h
@@ -31,7 +31,7 @@
  * the `gpv_InvalidEventConstructorTable` and `gpv_InvalidEventDestructorTable`
  * tables.
  */
-#define FIRST_NORMALISATION_RELATED_INVALID_EVENT_INDEX                      (6)
+#define FIRST_NORMALISATION_RELATED_INVALID_EVENT_INDEX                      (7)
 
 /******************************************************************************
  *  Global variables

--- a/libitc/test/include/ITC_TestUtil.h
+++ b/libitc/test/include/ITC_TestUtil.h
@@ -25,7 +25,7 @@
  * the `gpv_InvalidIdConstructorTable` and `gpv_InvalidIdDestructorTable`
  * tables.
  */
-#define FIRST_NORMALISATION_RELATED_INVALID_ID_INDEX                         (8)
+#define FIRST_NORMALISATION_RELATED_INVALID_ID_INDEX                         (9)
 
 /** The index of the first normalisation related invalid Event test inside
  * the `gpv_InvalidEventConstructorTable` and `gpv_InvalidEventDestructorTable`

--- a/libitc/test/mocked/ITC_Event_Test.c
+++ b/libitc/test/mocked/ITC_Event_Test.c
@@ -378,22 +378,24 @@ void ITC_Event_Test_fillEventIsRecoveredOnFailure(void)
     ITC_Event_t *pt_NewEvent2 = &t_NewEvent2;
 
     /* Create the ID to work with */
-    ITC_Id_t t_RootId = { 0 };
-    ITC_Id_t t_LeftChildId = { 0 };
-    ITC_Id_t t_RightChildId = { 0 };
+    ITC_Id_t t_ParentId = { 0 };
+    ITC_Id_t t_NestedSeedId = { 0 };
+    ITC_Id_t t_NestedNullId = { 0 };
+    ITC_Id_t t_SeedId = {0 };
 
     bool b_WasFilled;
 
-    /* Assign interval ownership */
-    t_RootId.b_IsOwner = false;
-    t_LeftChildId.b_IsOwner = true;
-    t_RightChildId.b_IsOwner = false;
+    /* Assign interval ownerships */
+    t_ParentId.b_IsOwner = false;
+    t_NestedSeedId.b_IsOwner = true;
+    t_NestedNullId.b_IsOwner = false;
+    t_SeedId.b_IsOwner = true;
 
-    /* Connect the ID tree */
-    t_RootId.pt_Left = &t_LeftChildId;
-    t_RootId.pt_Right = &t_RightChildId;
-    t_LeftChildId.pt_Parent = &t_RootId;
-    t_RightChildId.pt_Parent = &t_RootId;
+    /* Connect the parent ID tree */
+    t_ParentId.pt_Left = &t_NestedSeedId;
+    t_ParentId.pt_Right = &t_NestedNullId;
+    t_NestedSeedId.pt_Parent = &t_ParentId;
+    t_NestedNullId.pt_Parent = &t_ParentId;
 
     /* Setup expectations */
     ITC_Port_free_ExpectAndReturn(
@@ -415,7 +417,7 @@ void ITC_Event_Test_fillEventIsRecoveredOnFailure(void)
     gpt_ParentEvent->pt_Left->t_Count = 3;
     gpt_ParentEvent->pt_Right->t_Count = 0;
     TEST_FAILURE(
-        ITC_Event_fill(gpt_ParentEvent, t_RootId.pt_Left, &b_WasFilled),
+        ITC_Event_fill(gpt_ParentEvent, &t_SeedId, &b_WasFilled),
         ITC_STATUS_FAILURE);
 
     /* Test the Event is the same but the children have been restored */
@@ -432,7 +434,7 @@ void ITC_Event_Test_fillEventIsRecoveredOnFailure(void)
     gpt_ParentEvent->pt_Left->t_Count = 0;
     gpt_ParentEvent->pt_Right->t_Count = 1;
     TEST_FAILURE(
-        ITC_Event_fill(gpt_ParentEvent, &t_RootId, &b_WasFilled),
+        ITC_Event_fill(gpt_ParentEvent, &t_ParentId, &b_WasFilled),
         ITC_STATUS_EVENT_COUNTER_OVERFLOW);
 
     /* Test the Event was incremented but couldn't be normalised due to an
@@ -452,20 +454,22 @@ void ITC_Event_Test_growEventIsRecoveredOnFailure(void)
     ITC_Event_t *pt_NewEvent1 = &t_NewEvent1;
 
     /* Create the ID to work with */
-    ITC_Id_t t_RootId = { 0 };
-    ITC_Id_t t_LeftChildId = { 0 };
-    ITC_Id_t t_RightChildId = { 0 };
+    ITC_Id_t t_ParentId = { 0 };
+    ITC_Id_t t_NestedSeedId = { 0 };
+    ITC_Id_t t_NestedNullId = { 0 };
+    ITC_Id_t t_SeedId = {0 };
 
-    /* Assign interval ownership */
-    t_RootId.b_IsOwner = false;
-    t_LeftChildId.b_IsOwner = true;
-    t_RightChildId.b_IsOwner = false;
+    /* Assign interval ownerships */
+    t_ParentId.b_IsOwner = false;
+    t_NestedSeedId.b_IsOwner = true;
+    t_NestedNullId.b_IsOwner = false;
+    t_SeedId.b_IsOwner = true;
 
-    /* Connect the ID tree */
-    t_RootId.pt_Left = &t_LeftChildId;
-    t_RootId.pt_Right = &t_RightChildId;
-    t_LeftChildId.pt_Parent = &t_RootId;
-    t_RightChildId.pt_Parent = &t_RootId;
+    /* Connect the parent ID tree */
+    t_ParentId.pt_Left = &t_NestedSeedId;
+    t_ParentId.pt_Right = &t_NestedNullId;
+    t_NestedSeedId.pt_Parent = &t_ParentId;
+    t_NestedNullId.pt_Parent = &t_ParentId;
 
     /* Setup expectations */
     ITC_Port_malloc_ExpectAndReturn(
@@ -480,7 +484,8 @@ void ITC_Event_Test_growEventIsRecoveredOnFailure(void)
     ITC_Port_free_ExpectAndReturn(&t_NewEvent1, ITC_STATUS_SUCCESS);
 
     /* Test failing to grow a (0) Event with a (1, 0) ID */
-    TEST_FAILURE(ITC_Event_grow(gpt_LeafEvent, &t_RootId), ITC_STATUS_FAILURE);
+    TEST_FAILURE(
+        ITC_Event_grow(gpt_LeafEvent, &t_ParentId), ITC_STATUS_FAILURE);
 
     /* Test the Event is the same but the children have been restored */
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(gpt_LeafEvent, 0);
@@ -491,7 +496,7 @@ void ITC_Event_Test_growEventIsRecoveredOnFailure(void)
     /* Test failing to fill a (MAX_EVENT_COUNT) Event with a seed ID */
     gpt_LeafEvent->t_Count = ~((ITC_Event_Counter_t)0);
     TEST_FAILURE(
-        ITC_Event_grow(gpt_LeafEvent, t_RootId.pt_Left),
+        ITC_Event_grow(gpt_LeafEvent, &t_SeedId),
         ITC_STATUS_EVENT_COUNTER_OVERFLOW);
 
     /* Test the Event couldn't be incremented and was kept the same */

--- a/libitc/test/normal/ITC_Event_Test.c
+++ b/libitc/test/normal/ITC_Event_Test.c
@@ -206,49 +206,6 @@ void ITC_Event_Test_cloneEventSuccessful(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_ClonedEvent));
 }
 
-/* Test cloning a subtree of an Event succeeds */
-void ITC_Event_Test_cloneEventSubtreeSuccessful(void)
-{
-    ITC_Event_t *pt_OriginalEvent = NULL;
-    ITC_Event_t *pt_ClonedEvent = NULL;
-
-    /* clang-format off */
-    /* Test cloning an Event subree */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OriginalEvent, NULL, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OriginalEvent->pt_Left, pt_OriginalEvent, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OriginalEvent->pt_Right, pt_OriginalEvent, 0));
-    TEST_SUCCESS(ITC_Event_clone(pt_OriginalEvent->pt_Left, &pt_ClonedEvent));
-    TEST_ASSERT_TRUE(pt_OriginalEvent->pt_Left != pt_ClonedEvent);
-    TEST_SUCCESS(ITC_Event_destroy(&pt_OriginalEvent));
-    /* clang-format on */
-
-    TEST_ASSERT_FALSE(pt_ClonedEvent->pt_Parent);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_ClonedEvent, 1);
-    TEST_SUCCESS(ITC_Event_destroy(&pt_ClonedEvent));
-
-    /* clang-format off */
-    /* Test cloning a complex Event subree */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OriginalEvent, NULL, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OriginalEvent->pt_Left, pt_OriginalEvent, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OriginalEvent->pt_Left->pt_Left, pt_OriginalEvent->pt_Left, 2));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OriginalEvent->pt_Left->pt_Right, pt_OriginalEvent->pt_Left, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OriginalEvent->pt_Right, pt_OriginalEvent, 4));
-    TEST_SUCCESS(ITC_Event_clone(pt_OriginalEvent->pt_Left, &pt_ClonedEvent));
-    TEST_ASSERT_TRUE(pt_OriginalEvent->pt_Left != pt_ClonedEvent);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_ClonedEvent, 1);
-    TEST_ASSERT_TRUE(pt_OriginalEvent->pt_Left->pt_Left != pt_ClonedEvent->pt_Left);
-    TEST_ASSERT_TRUE(pt_OriginalEvent->pt_Left->pt_Right != pt_ClonedEvent->pt_Right);
-    TEST_SUCCESS(ITC_Event_destroy(&pt_OriginalEvent));
-    /* clang-format on */
-
-    TEST_ASSERT_FALSE(pt_ClonedEvent->pt_Parent);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_ClonedEvent->pt_Left, 2);
-    TEST_ASSERT_TRUE(pt_ClonedEvent->pt_Left->pt_Parent == pt_ClonedEvent);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_ClonedEvent->pt_Right, 0);
-    TEST_ASSERT_TRUE(pt_ClonedEvent->pt_Right->pt_Parent == pt_ClonedEvent);
-    TEST_SUCCESS(ITC_Event_destroy(&pt_ClonedEvent));
-}
-
 /* Test validating an Event fails with invalid param */
 void ITC_Event_Test_validateEventFailInvalidParam(void)
 {
@@ -340,36 +297,6 @@ void ITC_Event_Test_normaliseLeafEventSucceeds(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 }
 
-/* Test normalising a leaf event subtree succeeds */
-void ITC_Event_Test_normaliseLeafEventSubtreeSucceeds(void)
-{
-    ITC_Event_t *pt_Event = NULL;
-
-    /* Create the root event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 0));
-    /* Create the 0 leaf event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 0));
-    /* Create the 1 leaf event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 1));
-
-    /* Normalise the event subtree */
-    TEST_SUCCESS(ITC_Event_normalise(pt_Event->pt_Left));
-    /* Test the whole event tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Normalise the event subtree */
-    TEST_SUCCESS(ITC_Event_normalise(pt_Event->pt_Right));
-    /* Test the whole event tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Destroy the event*/
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-}
-
 /* Test normalising a parent event with leaf child event succeeds */
 void ITC_Event_Test_normaliseParentEventWithLeafChildrenSucceeds(void)
 {
@@ -401,56 +328,6 @@ void ITC_Event_Test_normaliseParentEventWithLeafChildrenSucceeds(void)
     TEST_SUCCESS(ITC_Event_normalise(pt_Event));
     /* Test the event has been normalised */
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event, 3);
-
-    /* Destroy the event*/
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-}
-
-/* Test normalising a parent event with leaf child event subtree succeeds */
-void ITC_Event_Test_normaliseParentEventSubtreeWithLeafChildrenSucceeds(void)
-{
-    ITC_Event_t *pt_Event = NULL;
-
-    /* clang-format off */
-    /* Create the root event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 2));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 2));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Left, pt_Event->pt_Left, 4));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Right, pt_Event->pt_Left, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 1));
-    /* clang-format on */
-
-    /* Normalise the event subtree */
-    TEST_SUCCESS(ITC_Event_normalise(pt_Event->pt_Left));
-    /* Test the event subtree has been normalised */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Left, 3);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Left, 3);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Right, 0);
-    /* Test the rest of the tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 2);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Normalise the normalised event subtree*/
-    TEST_SUCCESS(ITC_Event_normalise(pt_Event->pt_Left));
-    /* Test the event subtree has been normalised */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Left, 3);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Left, 3);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Right, 0);
-    /* Test the rest of the tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 2);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Make the children event count equal */
-    pt_Event->pt_Left->pt_Right->t_Count =
-        pt_Event->pt_Left->pt_Left->t_Count;
-
-    /* Normalise the event */
-    TEST_SUCCESS(ITC_Event_normalise(pt_Event->pt_Left));
-    /* Test the event has been normalised */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 6);
-    /* Test the rest of the tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 2);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
 
     /* Destroy the event*/
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
@@ -495,59 +372,6 @@ void ITC_Event_Test_normaliseComplexEventSucceeds(void)
     TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Right->pt_Right, 1);
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right->pt_Right->pt_Left, 1);
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right->pt_Right->pt_Right, 0);
-
-    /* Destroy the event*/
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-}
-
-/* Test normalising a complex event subtree succeeds */
-void ITC_Event_Test_normaliseComplexEventSubtreeSucceeds(void)
-{
-    ITC_Event_t *pt_Event = NULL;
-
-    /* clang-format off */
-    /* Create the complex event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Left, pt_Event->pt_Left, 3));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Left->pt_Left, pt_Event->pt_Left->pt_Left, 3));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Left->pt_Left->pt_Left, pt_Event->pt_Left->pt_Left->pt_Left, 3));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Left->pt_Left->pt_Right, pt_Event->pt_Left->pt_Left->pt_Left, 2));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Left->pt_Right, pt_Event->pt_Left->pt_Left, 4));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Right, pt_Event->pt_Left, 2));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Right->pt_Left, pt_Event->pt_Left->pt_Right, 2));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Right->pt_Right, pt_Event->pt_Left->pt_Right, 2));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 1));
-
-    /* Normalise the event subtree */
-    TEST_SUCCESS(ITC_Event_normalise(pt_Event->pt_Left));
-    /* Test the event subtree has been normalised */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Left, 5);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Left->pt_Left, 3);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Left->pt_Left->pt_Left, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Left->pt_Left->pt_Left, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Left->pt_Left->pt_Right, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Left->pt_Right, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Right, 0);
-    /* Test the rest of the tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Normalise the normalised event subtree */
-    TEST_SUCCESS(ITC_Event_normalise(pt_Event->pt_Left));
-    /* Test the event subtree hasn't changed */
-    /* Test the event subtree has been normalised */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Left, 5);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Left->pt_Left, 3);
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Left->pt_Left->pt_Left, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Left->pt_Left->pt_Left, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Left->pt_Left->pt_Right, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Left->pt_Right, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Right, 0);
-    /* Test the rest of the tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-    /* clang-format on */
 
     /* Destroy the event*/
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
@@ -604,36 +428,6 @@ void ITC_Event_Test_maximisingLeafEventSucceeds(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 }
 
-/* Test maximising a leaf Event subtree succeeds */
-void ITC_Event_Test_maximisingLeafEventSubtreeSucceeds(void)
-{
-    ITC_Event_t *pt_Event = NULL;
-
-    /* Create the 0 leaf event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 1));
-
-    /* Maximise the event */
-    TEST_SUCCESS(ITC_Event_maximise(pt_Event->pt_Left));
-    /* Test this is still a 0 leaf event */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 0);
-    /* Test the rest of the Event tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Maximise the event */
-    TEST_SUCCESS(ITC_Event_maximise(pt_Event->pt_Right));
-    /* Test this is still a 1 leaf event */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-    /* Test the rest of the Event tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 0);
-
-    /* Destroy the event*/
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-}
-
 /* Test maximising a parent Event succeeds */
 void ITC_Event_Test_maximisingParentEventSucceeds(void)
 {
@@ -660,52 +454,6 @@ void ITC_Event_Test_maximisingParentEventSucceeds(void)
     TEST_SUCCESS(ITC_Event_maximise(pt_Event));
     /* Test this is a leaf event with 6 events */
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event, 6);
-    /* Destroy the event*/
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-}
-
-/* Test maximising a parent Event subtree succeeds */
-void ITC_Event_Test_maximisingParentEventSubtreeSucceeds(void)
-{
-    ITC_Event_t *pt_Event = NULL;
-
-    /* clang-format off */
-    /* Create the event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 10));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Left, pt_Event->pt_Right, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Right, pt_Event->pt_Right, 5));
-    /* clang-format on */
-
-    /* Maximise the event */
-    TEST_SUCCESS(ITC_Event_maximise(pt_Event->pt_Right));
-    /* Test this is a leaf event with 5 events */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 5);
-    /* Test the rest of the Event tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 10);
-
-    /* Destroy the event*/
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-
-    /* clang-format off */
-    /* Create the event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 10));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Left, pt_Event->pt_Left, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Right, pt_Event->pt_Left, 5));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 0));
-    /* clang-format on */
-
-    /* Maximise the event */
-    TEST_SUCCESS(ITC_Event_maximise(pt_Event->pt_Left));
-    /* Test this is a leaf event with 6 events */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 6);
-    /* Test the rest of the Event tree hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 10);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 0);
-
     /* Destroy the event*/
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 }
@@ -801,36 +549,6 @@ void ITC_Event_Test_joinTwoIdenticalLeafEventsSucceeds(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_OtherEvent));
 }
 
-/* Test joining two identical leaf event subtrees succeeds */
-void ITC_Event_Test_joinTwoIdenticalLeafEventSubtreesSucceeds(void)
-{
-    ITC_Event_t *pt_Event;
-    ITC_Event_t *pt_OtherEvent;
-
-    /* clang-format off */
-    /* Construct the original Events */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OtherEvent, NULL, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OtherEvent->pt_Left, pt_OtherEvent, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OtherEvent->pt_Right, pt_OtherEvent, 0));
-    /* clang-format on */
-
-    /* Test joining the events */
-    TEST_SUCCESS(ITC_Event_join(&pt_Event->pt_Right, &pt_OtherEvent->pt_Left));
-    /* Test the joined event is a leaf with 1 counter */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Test the rest of the event hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 0);
-
-    /* Destroy the Events */
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-    TEST_SUCCESS(ITC_Event_destroy(&pt_OtherEvent));
-}
-
 /* Test joining two different leaf events succeeds */
 void ITC_Event_Test_joinTwoDifferentLeafEventsSucceeds(void)
 {
@@ -859,57 +577,6 @@ void ITC_Event_Test_joinTwoDifferentLeafEventsSucceeds(void)
 
             /* Test the joined event is a leaf with the bigger event counter */
             TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherEvent, 4);
-        }
-
-        /* Destroy the Events */
-        TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-        TEST_SUCCESS(ITC_Event_destroy(&pt_OtherEvent));
-    }
-}
-
-/* Test joining two different leaf event subtrees succeeds */
-void ITC_Event_Test_joinTwoDifferentLeafEventSubtreesSucceeds(void)
-{
-    ITC_Event_t *pt_Event;
-    ITC_Event_t *pt_OtherEvent;
-
-    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
-    {
-        /* clang-format off */
-        /* Construct the original Events */
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 1));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 0));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 4));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OtherEvent, NULL, 2));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OtherEvent->pt_Left, pt_OtherEvent, 2));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OtherEvent->pt_Right, pt_OtherEvent, 0));
-        /* clang-format on */
-
-        if(u32_I)
-        {
-            /* Test joining the events */
-            TEST_SUCCESS(
-                ITC_Event_join(&pt_Event->pt_Right, &pt_OtherEvent->pt_Left));
-
-            /* Test the joined event is a leaf with the bigger event counter */
-            TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 4);
-
-            /* Test the rest of the Event hasn't changed */
-            TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 1);
-            TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 0);
-        }
-        else
-        {
-            /* Test joining the events the other way around */
-            TEST_SUCCESS(
-                ITC_Event_join(&pt_OtherEvent->pt_Left, &pt_Event->pt_Right));
-
-            /* Test the joined event is a leaf with the bigger event counter */
-            TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherEvent->pt_Left, 4);
-
-            /* Test the rest of the Event hasn't changed */
-            TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_OtherEvent, 2);
-            TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherEvent->pt_Right, 0);
         }
 
         /* Destroy the Events */
@@ -951,64 +618,6 @@ void ITC_Event_Test_joinALeafAndAParentEventsSucceeds(void)
             TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_OtherEvent, 4);
             TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherEvent->pt_Left, 0);
             TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherEvent->pt_Right, 6);
-        }
-
-        /* Destroy the Events */
-        TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-        TEST_SUCCESS(ITC_Event_destroy(&pt_OtherEvent));
-    }
-}
-
-/* Test joining a leaf and a parent event subtrees succeeds */
-void ITC_Event_Test_joinALeafAndAParentEventSubtreesSucceeds(void)
-{
-    ITC_Event_t *pt_Event;
-    ITC_Event_t *pt_OtherEvent;
-
-    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
-    {
-        /* clang-format off */
-        /* Construct the original Events */
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 4));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 4));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Left, pt_Event->pt_Left, 0));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left->pt_Right, pt_Event->pt_Left, 6));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 0));
-
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OtherEvent, NULL, 2));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OtherEvent->pt_Left, pt_OtherEvent, 0));
-        TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_OtherEvent->pt_Right, pt_OtherEvent, 2));
-        /* clang-format on */
-
-        if (u32_I)
-        {
-            /* Test joining the events */
-            TEST_SUCCESS(
-                ITC_Event_join(&pt_Event->pt_Left, &pt_OtherEvent->pt_Right));
-
-            /* Test the joined event is a (4, 0, 6) event */
-            TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event->pt_Left, 4);
-            TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Left, 0);
-            TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left->pt_Right, 6);
-
-            /* Test the rest of the Event hasn't changed */
-            TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 4);
-            TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 0);
-        }
-        else
-        {
-          /* Test joining the events the other way around */
-          TEST_SUCCESS(
-              ITC_Event_join(&pt_OtherEvent->pt_Right, &pt_Event->pt_Left));
-
-          /* Test the joined event is a (4, 0, 6) event */
-          TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_OtherEvent->pt_Right, 4);
-          TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherEvent->pt_Right->pt_Left, 0);
-          TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherEvent->pt_Right->pt_Right, 6);
-
-          /* Test the rest of the Event hasn't changed */
-          TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_OtherEvent, 2);
-          TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_OtherEvent->pt_Left, 0);
         }
 
         /* Destroy the Events */
@@ -1345,38 +954,6 @@ void ITC_Event_Test_compareLeafEventsSucceeds(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event2));
 }
 
-/* Test comparing leaf Event subtrees succeeds */
-void ITC_Event_Test_compareLeafEventSubtreesSucceeds(void)
-{
-    ITC_Event_t *pt_Event1;
-    ITC_Event_t *pt_Event2;
-
-    /* Create the Events */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event1, NULL, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event1->pt_Left, pt_Event1, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event1->pt_Right, pt_Event1, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event2, NULL, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event2->pt_Left, pt_Event2, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event2->pt_Right, pt_Event2, 0));
-
-    /* Compare Events */
-    checkEventEqual(pt_Event1->pt_Left, pt_Event2->pt_Left);
-    /* Compare the other way around */
-    checkEventEqual(pt_Event2->pt_Left, pt_Event1->pt_Left);
-
-    /* Make the events different */
-    pt_Event1->pt_Left->t_Count += 2;
-
-    /* Compare Events */
-    checkEventGreaterThan(pt_Event1->pt_Left, pt_Event2->pt_Left);
-    /* Compare the other way around */
-    checkEventLessThan(pt_Event2->pt_Left, pt_Event1->pt_Left);
-
-    /* Destroy the Events */
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event1));
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event2));
-}
-
 /* Test comparing leaf and parent Event succeeds */
 void ITC_Event_Test_compareLeafAndParentEventsSucceeds(void)
 {
@@ -1405,46 +982,6 @@ void ITC_Event_Test_compareLeafAndParentEventsSucceeds(void)
     /* Check events are equal to themselves */
     checkEventEqual(pt_Event1, pt_Event1);
     checkEventEqual(pt_Event2, pt_Event2);
-
-    /* Destroy the Events */
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event1));
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event2));
-}
-
-/* Test comparing leaf and parent Event subtrees succeeds */
-void ITC_Event_Test_compareLeafAndParentEventSubtreesSucceeds(void)
-{
-    ITC_Event_t *pt_Event1;
-    ITC_Event_t *pt_Event2;
-
-    /* clang-format off */
-    /* Create the Events */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event1, NULL, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event1->pt_Left, pt_Event1, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event1->pt_Left->pt_Left, pt_Event1->pt_Left, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event1->pt_Left->pt_Right, pt_Event1->pt_Left, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event1->pt_Right, pt_Event1, 4));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event2, NULL, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event2->pt_Left, pt_Event2, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event2->pt_Right, pt_Event2, 0));
-    /* clang-format on */
-
-    /* Compare Events */
-    checkEventGreaterThan(pt_Event1->pt_Left, pt_Event2->pt_Left);
-    /* Compare the other way around */
-    checkEventLessThan(pt_Event2->pt_Left, pt_Event1->pt_Left);
-
-    /* Make Event 2 bigger */
-    pt_Event2->pt_Left->t_Count += 1;
-
-    /* Compare Events */
-    checkEventLessThan(pt_Event1->pt_Left, pt_Event2->pt_Left);
-    /* Compare the other way around */
-    checkEventGreaterThan(pt_Event2->pt_Left, pt_Event1->pt_Left);
-
-    /* Check events are equal to themselves */
-    checkEventEqual(pt_Event1->pt_Left, pt_Event1->pt_Left);
-    checkEventEqual(pt_Event2->pt_Left, pt_Event2->pt_Left);
 
     /* Destroy the Events */
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event1));
@@ -1711,147 +1248,6 @@ void ITC_Event_Test_fillLeafEventWithNullAndSeedIdsSucceeds(void)
     /* Destroy the IDs */
     TEST_SUCCESS(ITC_Id_destroy(&pt_SeedId));
     TEST_SUCCESS(ITC_Id_destroy(&pt_NullId));
-
-    /* Destroy the Events */
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-    TEST_SUCCESS(ITC_Event_destroy(&pt_OriginalEvent));
-}
-
-/* Test filling leaf Event subtree with null and seed IDs succeeds */
-void ITC_Event_Test_fillLeafEvenSubtreeWithNullAndSeedIdsSucceeds(void)
-{
-    ITC_Event_t *pt_Event;
-    ITC_Event_t *pt_OriginalEvent;
-    ITC_Id_t *pt_SeedId;
-    ITC_Id_t *pt_NullId;
-    bool b_WasFilled;
-
-    /* Create the IDs */
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_SeedId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_NullId, NULL));
-
-    /* Create the Event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 1));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 1));
-
-    /* Retain a copy for comparison */
-    TEST_SUCCESS(ITC_Event_clone(pt_Event, &pt_OriginalEvent));
-
-    /* Fill Event with null ID */
-    TEST_SUCCESS(ITC_Event_fill(pt_Event->pt_Left, pt_NullId, &b_WasFilled));
-
-    /* Test the Event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 0);
-    TEST_ASSERT_FALSE(b_WasFilled);
-    checkEventEqual(pt_OriginalEvent->pt_Left, pt_Event->pt_Left);
-    /* Test the rest of the Event hasn't changed either */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Fill Event with seed ID */
-    TEST_SUCCESS(ITC_Event_fill(pt_Event->pt_Left, pt_SeedId, &b_WasFilled));
-
-    /* Test the event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 0);
-    TEST_ASSERT_FALSE(b_WasFilled);
-    checkEventEqual(pt_OriginalEvent->pt_Left, pt_Event->pt_Left);
-    /* Test the rest of the Event hasn't changed either */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Make the event count different */
-    pt_Event->pt_Left->t_Count += 1;
-    pt_OriginalEvent->pt_Left->t_Count += 1;
-
-    /* Fill Event with null ID */
-    TEST_SUCCESS(ITC_Event_fill(pt_Event->pt_Left, pt_NullId, &b_WasFilled));
-
-    /* Test the event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 1);
-    TEST_ASSERT_FALSE(b_WasFilled);
-    checkEventEqual(pt_OriginalEvent->pt_Left, pt_Event->pt_Left);
-    /* Test the rest of the Event hasn't changed either */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Fill Event with seed ID */
-    TEST_SUCCESS(ITC_Event_fill(pt_Event->pt_Left, pt_SeedId, &b_WasFilled));
-
-    /* Test the event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 1);
-    TEST_ASSERT_FALSE(b_WasFilled);
-    checkEventEqual(pt_OriginalEvent->pt_Left, pt_Event->pt_Left);
-    /* Test the rest of the Event hasn't changed either */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 1);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 1);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SeedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_NullId));
-
-    /* Destroy the Events */
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-    TEST_SUCCESS(ITC_Event_destroy(&pt_OriginalEvent));
-}
-
-/* Test filling leaf Event with null and seed ID subtrees succeeds */
-void ITC_Event_Test_fillLeafEventWithNullAndSeedIdSubtreesSucceeds(void)
-{
-    ITC_Event_t *pt_Event;
-    ITC_Event_t *pt_OriginalEvent;
-    ITC_Id_t *pt_Id;
-    bool b_WasFilled;
-
-    /* Create the IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right, pt_Id));
-
-    /* Create the Event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 0));
-
-    /* Retain a copy for comparison */
-    TEST_SUCCESS(ITC_Event_clone(pt_Event, &pt_OriginalEvent));
-
-    /* Fill Event with null ID */
-    TEST_SUCCESS(ITC_Event_fill(pt_Event, pt_Id->pt_Left, &b_WasFilled));
-
-    /* Test the Event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event, 0);
-    TEST_ASSERT_FALSE(b_WasFilled);
-    checkEventEqual(pt_OriginalEvent, pt_Event);
-
-    /* Fill Event with seed ID */
-    TEST_SUCCESS(ITC_Event_fill(pt_Event, pt_Id->pt_Right, &b_WasFilled));
-
-    /* Test the event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event, 0);
-    TEST_ASSERT_FALSE(b_WasFilled);
-    checkEventEqual(pt_OriginalEvent, pt_Event);
-
-    /* Make the event count different */
-    pt_Event->t_Count += 1;
-    pt_OriginalEvent->t_Count += 1;
-
-    /* Fill Event with null ID */
-    TEST_SUCCESS(ITC_Event_fill(pt_Event, pt_Id->pt_Left, &b_WasFilled));
-
-    /* Test the event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event, 1);
-    TEST_ASSERT_FALSE(b_WasFilled);
-    checkEventEqual(pt_OriginalEvent, pt_Event);
-
-    /* Fill Event with seed ID */
-    TEST_SUCCESS(ITC_Event_fill(pt_Event, pt_Id->pt_Right, &b_WasFilled));
-
-    /* Test the event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event, 1);
-    TEST_ASSERT_FALSE(b_WasFilled);
-    checkEventEqual(pt_OriginalEvent, pt_Event);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 
     /* Destroy the Events */
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
@@ -2797,96 +2193,6 @@ void ITC_Event_Test_growLeafEventWithNullAndSeedIdsSucceeds(void)
     /* Destroy the IDs */
     TEST_SUCCESS(ITC_Id_destroy(&pt_SeedId));
     TEST_SUCCESS(ITC_Id_destroy(&pt_NullId));
-
-    /* Destroy the Events */
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-    TEST_SUCCESS(ITC_Event_destroy(&pt_OriginalEvent));
-}
-
-/* Test growing a leaf Event subtree with null and seed IDs succeeds */
-void ITC_Event_Test_growLeafEventSubtreeWithNullAndSeedIdsSucceeds(void)
-{
-    ITC_Event_t *pt_Event;
-    ITC_Event_t *pt_OriginalEvent;
-    ITC_Id_t *pt_SeedId;
-    ITC_Id_t *pt_NullId;
-
-    /* Create the IDs */
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_SeedId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_NullId, NULL));
-
-    /* Create the Event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 0));
-
-    /* Retain a copy for comparison */
-    TEST_SUCCESS(ITC_Event_clone(pt_Event, &pt_OriginalEvent));
-
-    /* Grow Event with null ID */
-    TEST_SUCCESS(ITC_Event_grow(pt_Event->pt_Left, pt_NullId));
-
-    /* Test the Event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Left, 0);
-    checkEventEqual(pt_OriginalEvent->pt_Left, pt_Event->pt_Left);
-    /* Test the rest of the Event hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 0);
-
-    /* Grow Event with seed ID */
-    TEST_SUCCESS(ITC_Event_grow(pt_Event->pt_Left, pt_SeedId));
-
-    /* Test the event has changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(
-        pt_Event->pt_Left, pt_OriginalEvent->t_Count + 1);
-    checkEventLessThan(pt_OriginalEvent->pt_Left, pt_Event->pt_Left);
-    /* Test the rest of the Event hasn't changed */
-    TEST_ITC_EVENT_IS_PARENT_N_EVENT(pt_Event, 0);
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right, 0);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_SeedId));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_NullId));
-
-    /* Destroy the Events */
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-    TEST_SUCCESS(ITC_Event_destroy(&pt_OriginalEvent));
-}
-
-/* Test growing a leaf Event with null and seed subtree IDs succeeds */
-void ITC_Event_Test_growLeafEventWithNullAndSeedSubtreeIdsSucceeds(void)
-{
-    ITC_Event_t *pt_Event;
-    ITC_Event_t *pt_OriginalEvent;
-    ITC_Id_t *pt_Id;
-
-    /* Create the IDs */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right, pt_Id));
-
-    /* Create the Event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 0));
-
-    /* Retain a copy for comparison */
-    TEST_SUCCESS(ITC_Event_clone(pt_Event, &pt_OriginalEvent));
-
-    /* Grow Event with null ID */
-    TEST_SUCCESS(ITC_Event_grow(pt_Event, pt_Id->pt_Left));
-
-    /* Test the Event hasn't changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event, 0);
-    checkEventEqual(pt_OriginalEvent, pt_Event);
-
-    /* Grow Event with seed ID */
-    TEST_SUCCESS(ITC_Event_grow(pt_Event, pt_Id->pt_Right));
-
-    /* Test the event has changed */
-    TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event, pt_OriginalEvent->t_Count + 1);
-    checkEventLessThan(pt_OriginalEvent, pt_Event);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 
     /* Destroy the Events */
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));

--- a/libitc/test/normal/ITC_Id_Test.c
+++ b/libitc/test/normal/ITC_Id_Test.c
@@ -163,63 +163,6 @@ void ITC_Id_Test_cloneIdSuccessful(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_ClonedId));
 }
 
-/* Test cloning a subtree of an ID succeeds */
-void ITC_Id_Test_cloneIdSubtreeSuccessful(void)
-{
-    ITC_Id_t *pt_OriginalId = NULL;
-    ITC_Id_t *pt_ClonedId = NULL;
-
-    /* clang-format off */
-    /* Test cloning seed subree ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right, pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_clone(pt_OriginalId->pt_Left, &pt_ClonedId));
-    TEST_ASSERT_TRUE(pt_OriginalId->pt_Left != pt_ClonedId);
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    /* clang-format on */
-
-    TEST_ASSERT_FALSE(pt_ClonedId->pt_Parent);
-    TEST_ITC_ID_IS_SEED_ID(pt_ClonedId);
-    TEST_SUCCESS(ITC_Id_destroy(&pt_ClonedId));
-
-    /* clang-format off */
-    /* Test cloning null subree ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right, pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_clone(pt_OriginalId->pt_Right, &pt_ClonedId));
-    TEST_ASSERT_TRUE(pt_OriginalId->pt_Right != pt_ClonedId);
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    /* clang-format on */
-
-    TEST_ASSERT_FALSE(pt_ClonedId->pt_Parent);
-    TEST_ITC_ID_IS_NULL_ID(pt_ClonedId);
-    TEST_SUCCESS(ITC_Id_destroy(&pt_ClonedId));
-
-    /* clang-format off */
-    /* Test cloning a complex ID subree */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left, pt_OriginalId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Left->pt_Left, pt_OriginalId->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OriginalId->pt_Left->pt_Right, pt_OriginalId->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OriginalId->pt_Right, pt_OriginalId));
-    TEST_SUCCESS(ITC_Id_clone(pt_OriginalId->pt_Left, &pt_ClonedId));
-    TEST_ASSERT_TRUE(pt_OriginalId->pt_Left != pt_ClonedId);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_ClonedId);
-    TEST_ASSERT_TRUE(pt_OriginalId->pt_Left->pt_Left != pt_ClonedId->pt_Left);
-    TEST_ASSERT_TRUE(pt_OriginalId->pt_Left->pt_Right != pt_ClonedId->pt_Right);
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OriginalId));
-    /* clang-format on */
-
-    TEST_ASSERT_FALSE(pt_ClonedId->pt_Parent);
-    TEST_ITC_ID_IS_NULL_ID(pt_ClonedId->pt_Left);
-    TEST_ASSERT_TRUE(pt_ClonedId->pt_Left->pt_Parent == pt_ClonedId);
-    TEST_ITC_ID_IS_SEED_ID(pt_ClonedId->pt_Right);
-    TEST_ASSERT_TRUE(pt_ClonedId->pt_Right->pt_Parent == pt_ClonedId);
-    TEST_SUCCESS(ITC_Id_destroy(&pt_ClonedId));
-}
-
 /* Test spliting an ID fails with invalid param */
 void ITC_Id_Test_splitIdFailInvalidParam(void)
 {
@@ -286,47 +229,6 @@ void ITC_Id_Test_splitNullAndSeedIdsSuccessful(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
-/* Test splitting a NULL and seed ID subtrees succeeds */
-void ITC_Id_Test_splitNullAndSeedIdSubtreesSuccessful(void)
-{
-    ITC_Id_t *pt_Id;
-    ITC_Id_t *pt_OtherId;
-
-    /* Create a new (0, 1) ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right, pt_Id));
-
-    /* Split the NULL ID */
-    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Left, &pt_OtherId));
-
-    /* Test the new IDs match (0, 0) */
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_OtherId);
-
-    /* Test the rest of the original ID hasn't changed */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
-    TEST_ITC_ID_IS_SEED_ID(pt_Id->pt_Right);
-
-    /* Destroy the other ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
-
-    /* Split the seed ID */
-    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Right, &pt_OtherId));
-
-    /* Test the new IDs match ((1, 0), (0, 1)) */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Right);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId);
-
-    /* Test the rest of the original ID hasn't changed */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
-}
-
 /* Test splitting a (0, 1) and (1, 0) ID succeeds */
 void ITC_Id_Test_split01And10IdsSuccessful(void)
 {
@@ -365,65 +267,6 @@ void ITC_Id_Test_split01And10IdsSuccessful(void)
     TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
     TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Left);
     TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Right);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
-}
-
-/* Test splitting a (0, 1) and (1, 0) ID subtrees succeeds */
-void ITC_Id_Test_split01And10IdSubtreesSuccessful(void)
-{
-    ITC_Id_t *pt_Id;
-    ITC_Id_t *pt_OtherId = NULL;
-
-    /* clang-format off */
-    /* Create a new (0, 1) ID subtree */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
-
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Left, pt_Id->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Right, pt_Id->pt_Right));
-    /* clang-format on */
-
-    /* Split the (0, 1) ID subtree */
-    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Right, &pt_OtherId));
-
-    /* Test the split IDs match ((0, (1, 0)), (0, (0, 1))) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id->pt_Right);
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right->pt_Left);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Right->pt_Right);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
-    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Right);
-
-    /* Test the rest of the original ID hasn't changed */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id->pt_Right));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
-
-    /* clang-format off */
-    /* Create a new (1, 0) ID subtree */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Left, pt_Id->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right->pt_Right, pt_Id->pt_Right));
-    /* clang-format on */
-
-    /* Split the (1, 0) ID subtree */
-    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Right, &pt_OtherId));
-
-    /* Test the new IDs match (((1, 0), 0), ((0, 1), 0)) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id->pt_Right);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Right->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right->pt_Right);
     TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
     TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Left);
     TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Right);
@@ -538,48 +381,6 @@ void ITC_Id_Test_split1001IdSuccessful(void)
     TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
     TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
     TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Right);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
-}
-
-/* Test splitting a ((1, 0), (0, 1)) ID subtree succeeds */
-void ITC_Id_Test_split1001IdSubtreeSuccessful(void)
-{
-    ITC_Id_t *pt_Id;
-    ITC_Id_t *pt_OtherId;
-
-    /* clang-format off */
-    /* Create a new ((1, 0), (0, 1)) ID subtree */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
-
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Left, pt_Id->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left->pt_Left->pt_Left, pt_Id->pt_Left->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Left->pt_Right, pt_Id->pt_Left->pt_Left));
-
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right, pt_Id->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right->pt_Left, pt_Id->pt_Left->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left->pt_Right->pt_Right, pt_Id->pt_Left->pt_Right));
-
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-    /* clang-format on */
-
-    /* Split the ((1, 0), (0, 1)) ID subtree */
-    TEST_SUCCESS(ITC_Id_split(&pt_Id->pt_Left, &pt_OtherId));
-
-    /* Test the split IDs match (((1, 0), 0), (0, (0, 1))) */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id->pt_Left);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Left->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left->pt_Right);
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
-    TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_OtherId->pt_Right);
-
-    /* Test the rest of the original ID hasn't changed */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
 
     /* Destroy the IDs */
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
@@ -726,32 +527,6 @@ void ITC_Id_Test_normaliseNullAndSeedIdsSuccessful(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 }
 
-/* Test normalising NULL and seed ID subtrees succeeds */
-void ITC_Id_Test_normaliseNullAndSeedIdSubtreesSuccessful(void)
-{
-    ITC_Id_t *pt_Id;
-
-    /* Create a new NULL and seed ID subtrees */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-
-    /* Normalise the NULL ID */
-    TEST_SUCCESS(ITC_Id_normalise(pt_Id->pt_Right));
-
-    /* Test the whole ID hasn't changed */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id);
-
-    /* Normalise the seed ID */
-    TEST_SUCCESS(ITC_Id_normalise(pt_Id->pt_Left));
-
-    /* Test the whole ID hasn't changed */
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id);
-
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-}
-
 /* Test normalising a (1, 0) and (0, 1) IDs succeeds */
 void ITC_Id_Test_normalise10And01IdsSuccessful(void)
 {
@@ -777,44 +552,6 @@ void ITC_Id_Test_normalise10And01IdsSuccessful(void)
 
     /* Test this is still a (1, 0) ID */
     TEST_ITC_ID_IS_NULL_SEED_ID(pt_Id);
-
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-}
-
-/* Test normalising a (1, 0) and (0, 1) ID subtrees succeeds */
-void ITC_Id_Test_normalise10And01IdSubtreesSuccessful(void)
-{
-    ITC_Id_t *pt_Id;
-
-    /* clang-format off */
-    /* Create a new (1, 0) ID subree */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left->pt_Left, pt_Id->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right, pt_Id->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-    /* clang-format on */
-
-    /* Normalise the ID */
-    TEST_SUCCESS(ITC_Id_normalise(pt_Id->pt_Left));
-
-    /* Test the whole ID hasn't changed */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
-    TEST_ITC_ID_IS_SEED_NULL_ID(pt_Id->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
-
-    /* Switch the (1, 0) ID into a (0, 1) ID */
-    pt_Id->pt_Left->pt_Left->b_IsOwner = false;
-    pt_Id->pt_Left->pt_Right->b_IsOwner = true;
-
-    /* Normalise the ID */
-    TEST_SUCCESS(ITC_Id_normalise(pt_Id->pt_Left));
-
-    /* Test the whole ID hasn't changed */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
-    TEST_ITC_ID_IS_NULL_SEED_ID(pt_Id->pt_Left);
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
 
     /* Destroy the ID */
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
@@ -849,50 +586,6 @@ void ITC_Id_Test_normalise11And00IdSuccessful(void)
 
     /* Test the ID is now a NULL ID */
     TEST_ITC_ID_IS_NULL_ID(pt_Id);
-
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-}
-
-/* Test normalising a (1, 1) and (0, 0) ID subtrees succeeds */
-void ITC_Id_Test_normalise11And00IdSubtreesSuccessful(void)
-{
-    ITC_Id_t *pt_Id;
-
-    /* clang-format off */
-    /* Create a new (1, 1) ID subtree (whole tree (1, (1, 1)) ) */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Left, pt_Id->pt_Right));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Right->pt_Right, pt_Id->pt_Right));
-    /* clang-format on */
-
-    /* Normalise the ID subtree */
-    TEST_SUCCESS(ITC_Id_normalise(pt_Id->pt_Right));
-
-    /* Test the targeted subtree has been normalised but the rest of the tree
-     * is untouched */
-    TEST_ITC_ID_IS_SEED_SEED_ID(pt_Id);
-
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-
-    /* clang-format off */
-    /* Create a new (0, 0) ID subtree (whole tree ((0, 0), 0) ) */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Left, pt_Id->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left->pt_Right, pt_Id->pt_Left));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-    /* clang-format on */
-
-    /* Normalise the ID subtree */
-    TEST_SUCCESS(ITC_Id_normalise(pt_Id->pt_Left));
-
-    /* Test the targeted subtree has been normalised but the rest of the tree
-     * is untouched */
-    TEST_ITC_ID_IS_NULL_NULL_ID(pt_Id);
 
     /* Destroy the ID */
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
@@ -1205,35 +898,6 @@ void ITC_Id_Test_sumId00Succeeds(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
 }
 
-/* Test summing two NULL ID subtrees succeeds */
-void ITC_Id_Test_sumId00SubtreesSucceeds(void)
-{
-    ITC_Id_t *pt_Id;
-    ITC_Id_t *pt_OtherId;
-
-    /* Create two NULL ID subtrees */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Left, pt_OtherId));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Right, pt_OtherId));
-
-    /* Sum the ID subtrees */
-    TEST_SUCCESS(ITC_Id_sum(&pt_Id->pt_Left, &pt_OtherId->pt_Right));
-
-    /* Test the summed ID is a NULL ID */
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Left);
-
-    /* Test the rest of the ID hasn't changed */
-    TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
-    TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
-
-    /* Destroy the IDs */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-    TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
-}
-
 /* Test summing a NULL and a seed ID succeeds */
 void ITC_Id_Test_sumId01And10Succeeds(void)
 {
@@ -1261,53 +925,6 @@ void ITC_Id_Test_sumId01And10Succeeds(void)
 
             /* Test the summed ID is a seed ID */
             TEST_ITC_ID_IS_SEED_ID(pt_OtherId);
-        }
-
-        /* Destroy the IDs */
-        TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-        TEST_SUCCESS(ITC_Id_destroy(&pt_OtherId));
-    }
-}
-
-/* Test summing a NULL and a seed ID subtrees succeeds */
-void ITC_Id_Test_sumId01And10SubtreesSucceeds(void)
-{
-    ITC_Id_t *pt_Id;
-    ITC_Id_t *pt_OtherId;
-
-    for (uint32_t u32_I = 0; u32_I < 2; u32_I++)
-    {
-        /* Create the NULL and seed IDs */
-        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Left, pt_Id));
-        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId, NULL));
-        TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_OtherId->pt_Left, pt_OtherId));
-        TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_OtherId->pt_Right, pt_OtherId));
-
-        if (u32_I)
-        {
-            /* Sum the IDs */
-            TEST_SUCCESS(ITC_Id_sum(&pt_Id->pt_Left, &pt_OtherId->pt_Right));
-
-            /* Test the summed ID is a seed ID */
-            TEST_ITC_ID_IS_SEED_ID(pt_Id->pt_Left);
-
-            /* Test the rest of the ID hasn't changed */
-            TEST_ITC_ID_IS_NOT_LEAF_ID(pt_Id);
-            TEST_ITC_ID_IS_NULL_ID(pt_Id->pt_Right);
-        }
-        else
-        {
-            /* Sum the IDs the other way around */
-            TEST_SUCCESS(ITC_Id_sum(&pt_OtherId->pt_Right, &pt_Id->pt_Left));
-
-            /* Test the summed ID is a seed ID */
-            TEST_ITC_ID_IS_SEED_ID(pt_OtherId->pt_Right);
-
-            /* Test the rest of the ID hasn't changed */
-            TEST_ITC_ID_IS_NOT_LEAF_ID(pt_OtherId);
-            TEST_ITC_ID_IS_NULL_ID(pt_OtherId->pt_Left);
         }
 
         /* Destroy the IDs */

--- a/libitc/test/normal/ITC_SerDes_Test.c
+++ b/libitc/test/normal/ITC_SerDes_Test.c
@@ -209,64 +209,6 @@ void ITC_SerDes_Test_serialiseIdFailWithInsufficentResources(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 }
 
-/* Test serialising a leaf ID subtree succeeds */
-void ITC_SerDes_Test_serialiseIdLeafSubtreeSuccessful(void)
-{
-    ITC_Id_t *pt_Id = NULL;
-    uint8_t ru8_Buffer[10] = { 0 };
-    uint32_t u32_BufferSize = sizeof(ru8_Buffer);
-
-    uint8_t ru8_ExpectedSeedIdSerialisedData[] = {
-        ITC_VERSION_MAJOR, /* Provided by build system c args */
-        ITC_SERDES_SEED_ID_HEADER
-    };
-    uint8_t ru8_ExpectedNullIdSerialisedData[] = {
-        ITC_VERSION_MAJOR, /* Provided by build system c args */
-        ITC_SERDES_NULL_ID_HEADER
-    };
-
-    /* Create a new ID */
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id, NULL));
-    TEST_SUCCESS(ITC_TestUtil_newSeedId(&pt_Id->pt_Left, pt_Id));
-    TEST_SUCCESS(ITC_TestUtil_newNullId(&pt_Id->pt_Right, pt_Id));
-
-    /* Serialise the ID */
-    TEST_SUCCESS(
-        ITC_SerDes_Util_serialiseId(
-            pt_Id->pt_Left,
-            &ru8_Buffer[0],
-            &u32_BufferSize,
-            true));
-
-    /* Test the serialised data is what is expected */
-    TEST_ASSERT_EQUAL(sizeof(ru8_ExpectedSeedIdSerialisedData), u32_BufferSize);
-    TEST_ASSERT_EQUAL_MEMORY(
-        &ru8_ExpectedSeedIdSerialisedData[0],
-        &ru8_Buffer[0],
-        sizeof(ru8_ExpectedSeedIdSerialisedData));
-
-    /* Reset the buffer size */
-    u32_BufferSize = sizeof(ru8_Buffer);
-
-    /* Serialise the ID */
-    TEST_SUCCESS(
-        ITC_SerDes_Util_serialiseId(
-            pt_Id->pt_Right,
-            &ru8_Buffer[0],
-            &u32_BufferSize,
-            true));
-
-    /* Test the serialised data is what is expected */
-    TEST_ASSERT_EQUAL(sizeof(ru8_ExpectedNullIdSerialisedData), u32_BufferSize);
-    TEST_ASSERT_EQUAL_MEMORY(
-        &ru8_ExpectedNullIdSerialisedData[0],
-        &ru8_Buffer[0],
-        sizeof(ru8_ExpectedNullIdSerialisedData));
-
-    /* Destroy the ID */
-    TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
-}
-
 /* Test serialising a parent ID succeeds */
 void ITC_SerDes_Test_serialiseIdParentSuccessful(void)
 {

--- a/libitc/test/normal/ITC_SerDes_Test.c
+++ b/libitc/test/normal/ITC_SerDes_Test.c
@@ -642,42 +642,6 @@ void ITC_SerDes_Test_serialiseEventFailWithInsufficentResources(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 }
 
-/* Test serialising a leaf Event subtree succeeds */
-void ITC_SerDes_Test_serialiseEventLeafSubtreeSuccessful(void)
-{
-    ITC_Event_t *pt_Event = NULL;
-    uint8_t ru8_Buffer[10] = { 0 };
-    uint32_t u32_BufferSize = sizeof(ru8_Buffer);
-
-    uint8_t ru8_ExpectedEventSerialisedData[] = {
-        ITC_VERSION_MAJOR, /* Provided by build system c args */
-        ITC_SERDES_CREATE_EVENT_HEADER(false, 0)
-    };
-
-    /* Create a new Event */
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event, NULL, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Left, pt_Event, 0));
-    TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right, pt_Event, 1));
-
-    /* Serialise the Event */
-    TEST_SUCCESS(
-        ITC_SerDes_Util_serialiseEvent(
-            pt_Event->pt_Left,
-            &ru8_Buffer[0],
-            &u32_BufferSize,
-            true));
-
-    /* Test the serialised data is what is expected */
-    TEST_ASSERT_EQUAL(sizeof(ru8_ExpectedEventSerialisedData), u32_BufferSize);
-    TEST_ASSERT_EQUAL_MEMORY(
-        &ru8_ExpectedEventSerialisedData[0],
-        &ru8_Buffer[0],
-        sizeof(ru8_ExpectedEventSerialisedData));
-
-    /* Destroy the Event */
-    TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
-}
-
 /* Test serialising a parent Event succeeds */
 void ITC_SerDes_Test_serialiseEventParentSuccessful(void)
 {


### PR DESCRIPTION
The possibility of being given an ID/Event subtree is a side effect of having parent pointers in the ID/Event structs. This pointer is needed to avoid resorting to recursion when traversing the trees.

The ITC specification (as presented in the research paper) does not use parent pointers and thus does not know whether a given ID/Event tree is a subtree of another node. It just treats all nodes as if they are roots.

For this reason, it is at the very least pointless to allow subtrees to be passed in as input to the public API, as they have no special/different meaning in the ITC specification (in fact they don't even exist there). Passing a subtree node as input is likely a sign that something is wrong with the ID/Event node itself. Such a node should not be used as even though the code _should_ handle it correctly (treating it as if it were a root node), it may still lead to undefined and undesired behaviour since the caller most likely passed the subtree node by mistake and instead wanted to pass in a root node.