### PR TITLE
Fix invalid param being returned when a NULL is paseed to ITC_Stamp_destroy

### DIFF
--- a/libitc/ITC_Stamp.c
+++ b/libitc/ITC_Stamp.c
@@ -746,11 +746,11 @@ ITC_Status_t ITC_Stamp_destroy(
     ITC_Status_t t_Status = ITC_STATUS_SUCCESS; /* The current status */
     ITC_Status_t t_FreeStatus = ITC_STATUS_SUCCESS; /* The last free status */
 
-    if (!ppt_Stamp || !(*ppt_Stamp))
+    if (!ppt_Stamp)
     {
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
-    else
+    else if (*ppt_Stamp)
     {
         if ((*ppt_Stamp)->pt_Event)
         {

--- a/libitc/test/normal/ITC_Event_Test.c
+++ b/libitc/test/normal/ITC_Event_Test.c
@@ -114,8 +114,8 @@ void ITC_Event_Test_destroyEventSuccessful(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Dummy));
 }
 
-/* Test creating a NULL Event fails with invalid param */
-void ITC_Event_Test_createNullEventFailInvalidParam(void)
+/* Test creating a Event fails with invalid param */
+void ITC_Event_Test_createEventFailInvalidParam(void)
 {
     TEST_FAILURE(ITC_Event_new(NULL), ITC_STATUS_INVALID_PARAM);
 }

--- a/libitc/test/normal/ITC_Stamp_Test.c
+++ b/libitc/test/normal/ITC_Stamp_Test.c
@@ -31,10 +31,18 @@ void tearDown(void) {}
 /* Test destroying a Stamp fails with invalid param */
 void ITC_Stamp_Test_destroyStampFailInvalidParam(void)
 {
+    TEST_FAILURE(ITC_Stamp_destroy(NULL), ITC_STATUS_INVALID_PARAM);
+}
+
+/* Test destroying a Stamp suceeds */
+void ITC_Stamp_Test_destroyStampSuccessful(void)
+{
     ITC_Stamp_t *pt_Dummy = NULL;
 
-    TEST_FAILURE(ITC_Stamp_destroy(NULL), ITC_STATUS_INVALID_PARAM);
-    TEST_FAILURE(ITC_Stamp_destroy(&pt_Dummy), ITC_STATUS_INVALID_PARAM);
+    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Dummy));
+
+    TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Dummy));
+    TEST_SUCCESS(ITC_Stamp_destroy(&pt_Dummy));
 }
 
 /* Test creating a Stamp fails with invalid param */


### PR DESCRIPTION
Destroy functions should tolerate passing a pointer with a `NULL` value as input. I.e:

```c
ITC_Stamp_t *pt_Stamp = NULL;

ITC_Stamp_destroy(&pt_Stamp) == ITC_STATUS_SUCCESS // true
```
