### PR TITLE
Create releases only on tag; Fix bugfix changelog label name

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -11,7 +11,7 @@ changelog:
         - enhancement
     - title: Bugfixes 🐛
       labels:
-        - bug
+        - bugfix
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,6 @@ name: Release
 on:
   push:
     branches: [ main ]
-    tags:
-      - "v*.*.*"
 
 permissions:
   contents: write
@@ -15,18 +13,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check Pre-release
-        id: check-pre-release
+      - name: Check For Release
+        id: check-for-release
         run: |
-          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "pre-release=false" >> $GITHUB_OUTPUT
+          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            echo "is-release=true" >> $GITHUB_OUTPUT
+            if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "pre-release=false" >> $GITHUB_OUTPUT
+            else
+                echo "pre-release=true" >> $GITHUB_OUTPUT
+            fi
           else
-              echo "pre-release=true" >> $GITHUB_OUTPUT
+            echo "is-release=false" >> $GITHUB_OUTPUT
           fi
       - name: Release
+        if: ${{ steps.check-for-release.outputs.is-release == 'true' }}
         uses: softprops/action-gh-release@v2
         with:
           draft: true
           generate_release_notes: true
           append_body: true
-          prerelease: ${{ steps.check-pre-release.outputs.pre-release == 'true' }}
+          prerelease: ${{ steps.check-for-release.outputs.pre-release == 'true' }}


### PR DESCRIPTION
- Changes `bug` label to `bugfix`
- Fixes (hopefully) the release action to only create releases on tagged commits
