### PR TITLE
Fix memory leak if a destroy call fails during join, sum or split op

### DIFF
--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -2073,23 +2073,23 @@ ITC_Status_t ITC_Event_join(
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-      /* XXX: Save the parent pointer in case the original Event was a subtree.
-       * This makes no sense from a functional point of view, especially
-       * since `validateEvent` should fail if a subtree is passed in.
-       * However, if that somehow fails and a subtree is joined, the new Event
-       * will lose the reference to the original Event subtree's parent nodes,
-       * which would lead to a memory leak. */
-      pt_JoinedEvent->pt_Parent = (*ppt_Event)->pt_Parent;
+        /* XXX: Save the parent pointer in case the original Event was a subtree.
+         * This makes no sense from a functional point of view, especially
+         * since `validateEvent` should fail if a subtree is passed in.
+         * However, if that somehow fails and a subtree is joined, the new Event
+         * will lose the reference to the original Event subtree's parent nodes,
+         * which would lead to a memory leak. */
+        pt_JoinedEvent->pt_Parent = (*ppt_Event)->pt_Parent;
 
-      /* Destroy the old Events */
-      /* Ignore return statuses. There is nothing else to do if the destroy
-       * fails. Also it is more important to convey that the overall join
-       * operation was successful */
-      (void)ITC_Event_destroy(ppt_Event);
-      (void)ITC_Event_destroy(ppt_OtherEvent);
+        /* Destroy the old Events
+         * Ignore return statuses. There is nothing else to do if the destroy
+         * fails. Also it is more important to convey that the overall join
+         * operation was successful */
+        (void)ITC_Event_destroy(ppt_Event);
+        (void)ITC_Event_destroy(ppt_OtherEvent);
 
-      /* Return the joined Event */
-      *ppt_Event = pt_JoinedEvent;
+        /* Return the joined Event */
+        *ppt_Event = pt_JoinedEvent;
     }
 
     return t_Status;

--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -2073,22 +2073,23 @@ ITC_Status_t ITC_Event_join(
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        /* Destroy the second Event */
-        t_Status = ITC_Event_destroy(ppt_OtherEvent);
-    }
+      /* XXX: Save the parent pointer in case the original Event was a subtree.
+       * This makes no sense from a functional point of view, especially
+       * since `validateEvent` should fail if a subtree is passed in.
+       * However, if that somehow fails and a subtree is joined, the new Event
+       * will lose the reference to the original Event subtree's parent nodes,
+       * which would lead to a memory leak. */
+      pt_JoinedEvent->pt_Parent = (*ppt_Event)->pt_Parent;
 
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        /* Save the parent pointer in case the original Event was a subtree */
-        pt_JoinedEvent->pt_Parent = (*ppt_Event)->pt_Parent;
+      /* Destroy the old Events */
+      /* Ignore return statuses. There is nothing else to do if the destroy
+       * fails. Also it is more important to convey that the overall join
+       * operation was successful */
+      (void)ITC_Event_destroy(ppt_Event);
+      (void)ITC_Event_destroy(ppt_OtherEvent);
 
-        /* Destroy the first Event */
-        t_Status = ITC_Event_destroy(ppt_Event);
-    }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        *ppt_Event = pt_JoinedEvent;
+      /* Return the joined Event */
+      *ppt_Event = pt_JoinedEvent;
     }
 
     return t_Status;

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -1330,6 +1330,7 @@ ITC_Status_t ITC_Id_split(
          * operation was successful */
         (void)ITC_Id_destroy(ppt_Id);
 
+        /* Return the first half of the split ID */
         *ppt_Id = pt_NewId;
     }
 

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -1316,14 +1316,20 @@ ITC_Status_t ITC_Id_split(
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        /* Save the parent pointer in case the original ID was a subtree */
+        /* XXX: Save the parent pointer in case the original ID was a subtree.
+         * This makes no sense from a functional point of view, especially
+         * since `validateId` should fail if a subtree is passed in. However,
+         * if that somehow fails and a subtree is split, the new Id will lose
+         * the reference to the original Id subtree's parent nodes, which
+         * would lead to a memory leak. */
         pt_NewId->pt_Parent = (*ppt_Id)->pt_Parent;
 
-        t_Status = ITC_Id_destroy(ppt_Id);
-    }
+        /* Destroy the old ID */
+        /* Ignore return statuses. There is nothing else to do if the destroy
+         * fails. Also it is more important to convey that the overall sum
+         * operation was successful */
+        (void)ITC_Id_destroy(ppt_Id);
 
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
         *ppt_Id = pt_NewId;
     }
 
@@ -1364,21 +1370,22 @@ ITC_Status_t ITC_Id_sum(
 
     if (t_Status == ITC_STATUS_SUCCESS)
     {
-        /* Destroy the second ID */
-        t_Status = ITC_Id_destroy(ppt_OtherId);
-    }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        /* Save the parent pointer in case the original ID was a subtree */
+        /* XXX: Save the parent pointer in case the original ID was a subtree.
+         * This makes no sense from a functional point of view, especially
+         * since `validateId` should fail if a subtree is passed in. However,
+         * if that somehow fails and a subtree is summed, the new Id will lose
+         * the reference to the original Id subtree's parent nodes, which
+         * would lead to a memory leak. */
         pt_SummedId->pt_Parent = (*ppt_Id)->pt_Parent;
 
-        /* Destroy the first ID */
-        t_Status = ITC_Id_destroy(ppt_Id);
-    }
+        /* Destroy the old IDs */
+        /* Ignore return statuses. There is nothing else to do if the destroy
+         * fails. Also it is more important to convey that the overall sum
+         * operation was successful */
+        (void)ITC_Id_destroy(ppt_Id);
+        (void)ITC_Id_destroy(ppt_OtherId);
 
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
+        /* Return the summed ID */
         *ppt_Id = pt_SummedId;
     }
 

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -1324,8 +1324,8 @@ ITC_Status_t ITC_Id_split(
          * would lead to a memory leak. */
         pt_NewId->pt_Parent = (*ppt_Id)->pt_Parent;
 
-        /* Destroy the old ID */
-        /* Ignore return statuses. There is nothing else to do if the destroy
+        /* Destroy the old ID.
+         * Ignore return statuses. There is nothing else to do if the destroy
          * fails. Also it is more important to convey that the overall sum
          * operation was successful */
         (void)ITC_Id_destroy(ppt_Id);
@@ -1378,8 +1378,8 @@ ITC_Status_t ITC_Id_sum(
          * would lead to a memory leak. */
         pt_SummedId->pt_Parent = (*ppt_Id)->pt_Parent;
 
-        /* Destroy the old IDs */
-        /* Ignore return statuses. There is nothing else to do if the destroy
+        /* Destroy the old IDs.
+         * Ignore return statuses. There is nothing else to do if the destroy
          * fails. Also it is more important to convey that the overall sum
          * operation was successful */
         (void)ITC_Id_destroy(ppt_Id);

--- a/libitc/test/mocked/ITC_Event_Test.c
+++ b/libitc/test/mocked/ITC_Event_Test.c
@@ -308,8 +308,8 @@ void ITC_Event_Test_joinOriginalAndCopiedEventsAreDestroyedOnSucess(void)
 
     ITC_Port_free_ExpectAndReturn(pt_NewEvent1, ITC_STATUS_SUCCESS);
     ITC_Port_free_ExpectAndReturn(pt_NewEvent2, ITC_STATUS_SUCCESS);
-    ITC_Port_free_ExpectAndReturn(pt_OtherEvent, ITC_STATUS_SUCCESS);
     ITC_Port_free_ExpectAndReturn(gpt_LeafEvent, ITC_STATUS_SUCCESS);
+    ITC_Port_free_ExpectAndReturn(pt_OtherEvent, ITC_STATUS_SUCCESS);
 
     /* Test joining the Events */
     TEST_SUCCESS(ITC_Event_join(&gpt_LeafEvent, &pt_OtherEvent));

--- a/libitc/test/mocked/ITC_Id_Test.c
+++ b/libitc/test/mocked/ITC_Id_Test.c
@@ -339,8 +339,8 @@ void ITC_Id_Test_sumIdOriginalIdsAreDestroyedOnSuccess(void)
     ITC_Port_malloc_IgnoreArg_ppv_Ptr();
     ITC_Port_malloc_ReturnThruPtr_ppv_Ptr((void **)&pt_NewId1);
 
-    ITC_Port_free_ExpectAndReturn(pt_OtherId, ITC_STATUS_SUCCESS);
     ITC_Port_free_ExpectAndReturn(gpt_LeafId, ITC_STATUS_SUCCESS);
+    ITC_Port_free_ExpectAndReturn(pt_OtherId, ITC_STATUS_SUCCESS);
 
     /* Test summing the IDs */
     pt_OtherId->b_IsOwner = false;


### PR DESCRIPTION
Fixes a potential memory leak if an ID sum/split or Event join operation partially fails.

If at least one source ID/Event fails to get destroyed (for whatever reason), the new ID/Event will not be returned to the caller, which would cause a memory leak. 

Arguably the `destroy` call failure is also a memory leak, but there is nothing else to do if that happens. 