### PR TITLE
Added `serialiseToString` API

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -22,6 +22,7 @@ jobs:
         compiler: ['gcc']
         USE_64BIT_EVENT_COUNTERS: [0, 1]
         ENABLE_EXTENDED_API: [0, 1]
+        ENABLE_SERIALISE_TO_STRING_API: [0, 1]
     steps:
       - name: Install compiler
         uses: rlalik/setup-cpp-compiler@master
@@ -40,6 +41,7 @@ jobs:
           CFLAGS="
             -DITC_CONFIG_ENABLE_EXTENDED_API=${{ matrix.ENABLE_EXTENDED_API }}
             -DITC_CONFIG_USE_64BIT_EVENT_COUNTERS=${{ matrix.USE_64BIT_EVENT_COUNTERS }}
+            -DITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API=${{ matrix.ENABLE_SERIALISE_TO_STRING_API }}
           "
           meson setup --wipe --reconfigure
           ${{ env.BUILD_DIR_PREFIX }}

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -38,15 +38,15 @@ jobs:
       - name: Configure Tests
         run: >-
           CC=${{ matrix.compiler }}
-          CFLAGS="
-            -DITC_CONFIG_ENABLE_EXTENDED_API=${{ matrix.ENABLE_EXTENDED_API }}
-            -DITC_CONFIG_USE_64BIT_EVENT_COUNTERS=${{ matrix.USE_64BIT_EVENT_COUNTERS }}
-            -DITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API=${{ matrix.ENABLE_SERIALISE_TO_STRING_API }}
-          "
           meson setup --wipe --reconfigure
           ${{ env.BUILD_DIR_PREFIX }}
           -Doptimization=${{ env.OPTIMIZATION }}
           -Ddebug=${{ env.DEBUG }}
           -Dtests=true
+          -Dc_args="
+            -DITC_CONFIG_ENABLE_EXTENDED_API=${{ matrix.ENABLE_EXTENDED_API }}
+            -DITC_CONFIG_USE_64BIT_EVENT_COUNTERS=${{ matrix.USE_64BIT_EVENT_COUNTERS }}
+            -DITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API=${{ matrix.ENABLE_SERIALISE_TO_STRING_API }}
+          "
       - name: Build And Run Tests
         run: CC=${{ matrix.compiler }} meson test -C ${{ env.BUILD_DIR_PREFIX }}

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ libitc strives to be flexible and allows turning on/off optional features. This 
 
 See [`ITC_config.h`](./libitc/include/ITC_config.h) for all available options.
 
-You can modify the header file directly to change the default configuration, or you can provide alternative values via `CFLAGS` during the [build configuration](#build-configuration) stage.
+You can modify the header file directly to change the default configuration, or you can provide alternative values via `CFLAGS` or the [builtin `c_args` Meson option](https://mesonbuild.com/Builtin-options.html#:~:text=Description-,c_args,-free%2Dform%20comma) during the [build configuration](#build-configuration) stage.
 
 For example, to enable the extended API, you can configure the build like so:
 
 ```bash
-CFLAGS="-DITC_CONFIG_ENABLE_EXTENDED_API=1" meson setup -Doptimization=2 -Ddebug=false build-with-extended-api
+meson setup -Doptimization=2 -Ddebug=false -Dc_args="-DITC_CONFIG_ENABLE_EXTENDED_API=1" build-with-extended-api
 ```
 
 #### Compilation

--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -1821,9 +1821,9 @@ static ITC_Status_t serialiseEventToString(
     /* The size of the stringified current node event counter */
     uint32_t u32_EventCounterSize = 0;
 
+    /* Ensure there is at least space for the NULL termination */
     if (*pu32_BufferSize < 1)
     {
-        /* Ensure there is at least space for the NULL termination */
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
 
@@ -1831,7 +1831,7 @@ static ITC_Status_t serialiseEventToString(
     while (t_Status == ITC_STATUS_SUCCESS && pt_Event)
     {
         /* Check there is space left in the buffer, taking into account the
-         * NULL termination byte */
+         * NULL termination byte and bracket */
         if (u32_Offset >= (*pu32_BufferSize - 1))
         {
             t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;
@@ -1845,7 +1845,7 @@ static ITC_Status_t serialiseEventToString(
             u32_Offset++;
 
             /* Check there is space left in the buffer, taking into account the
-             * NULL termination byte */
+             * NULL termination byte and at least 1 digit event counter */
              if (u32_Offset >= (*pu32_BufferSize - 1))
              {
                  t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;

--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -1731,7 +1731,7 @@ static ITC_Status_t serialiseEvent(
     return t_Status;
 }
 
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 
 /**
  * @brief Serialise an Event counter to ASCII string
@@ -1984,7 +1984,7 @@ static ITC_Status_t serialiseEventToString(
     return t_Status;
 }
 
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 
 
 /**

--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -15,9 +15,9 @@
 #include "ITC_SerDes_private.h"
 #include "ITC_SerDes_Util_package.h"
 
-#if ITC_CONFIG_ENABLE_EXTENDED_API || ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_EXTENDED_API
 #include "ITC_SerDes.h"
-#endif /* ITC_CONFIG_ENABLE_EXTENDED_API || ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 
 #include "ITC_Id_package.h"
 #include "ITC_Id_private.h"
@@ -1727,7 +1727,7 @@ static ITC_Status_t serialiseEvent(
     return t_Status;
 }
 
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
 
 /**
  * @brief Serialise an Event counter to ASCII string
@@ -1980,7 +1980,7 @@ static ITC_Status_t serialiseEventToString(
     return t_Status;
 }
 
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 
 
 /**
@@ -2557,6 +2557,8 @@ ITC_Status_t ITC_SerDes_Util_deserialiseEvent(
     return t_Status;
 }
 
+#if ITC_CONFIG_ENABLE_EXTENDED_API
+
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 
 /******************************************************************************
@@ -2592,8 +2594,6 @@ ITC_Status_t ITC_SerDes_serialiseEventToString(
 }
 
 #endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
-
-#if ITC_CONFIG_ENABLE_EXTENDED_API
 
 /******************************************************************************
  * Serialise an existing ITC Event

--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -19,6 +19,10 @@
 #include "ITC_SerDes.h"
 #endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 
+#if !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API)
+#include "ITC_SerDes_package.h"
+#endif /* !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API) */
+
 #include "ITC_Id_package.h"
 #include "ITC_Id_private.h"
 #include "ITC_Port.h"
@@ -2557,8 +2561,6 @@ ITC_Status_t ITC_SerDes_Util_deserialiseEvent(
     return t_Status;
 }
 
-#if ITC_CONFIG_ENABLE_EXTENDED_API
-
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 
 /******************************************************************************
@@ -2594,6 +2596,8 @@ ITC_Status_t ITC_SerDes_serialiseEventToString(
 }
 
 #endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+
+#if ITC_CONFIG_ENABLE_EXTENDED_API
 
 /******************************************************************************
  * Serialise an existing ITC Event

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -15,9 +15,9 @@
 #include "ITC_SerDes_private.h"
 #include "ITC_SerDes_Util_package.h"
 
-#if ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_EXTENDED_API || ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 #include "ITC_SerDes.h"
-#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API || ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 
 #include "ITC_Port.h"
 
@@ -984,6 +984,160 @@ static ITC_Status_t serialiseId(
     return t_Status;
 }
 
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+
+/**
+ * @brief Serialise an existing ITC Id to string
+ *
+ * @param ppt_Id The pointer to the Id
+ * @param pc_Buffer The buffer to hold the serialised data
+ * @param pu32_BufferSize (in) The size of the buffer in bytes. (out) The size
+ * of the data inside the buffer in bytes.
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
+ * @retval `ITC_STATUS_INSUFFICIENT_RESOURCES` if the buffer is not big enough
+ */
+static ITC_Status_t serialiseIdToString(
+    const ITC_Id_t *pt_Id,
+    char *const pc_Buffer,
+    uint32_t *const pu32_BufferSize
+)
+{
+    ITC_Status_t t_Status = ITC_STATUS_SUCCESS; /* The current status */
+    const ITC_Id_t *pt_CurrentIdParent = NULL; /* The current ID node */
+    const ITC_Id_t *pt_RootIdParent = pt_Id->pt_Parent; /* The root parent */
+    uint32_t u32_Offset = 0;
+
+    if (*pu32_BufferSize < 1)
+    {
+        /* Ensure there is at least space for the NULL termination */
+        t_Status = ITC_STATUS_INVALID_PARAM;
+    }
+
+    /* Perform a pre-order traversal */
+    while (t_Status == ITC_STATUS_SUCCESS && pt_Id)
+    {
+        /* Check there is space left in the buffer, taking into account the
+         * NULL termination byte */
+        if (u32_Offset >= (*pu32_BufferSize - 1))
+        {
+            t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;
+        }
+        else
+        {
+            if (ITC_ID_IS_PARENT_ID(pt_Id))
+            {
+                /* Open a bracket to signify a parent node */
+                pc_Buffer[u32_Offset] = '(';
+            }
+            else if (pt_Id->b_IsOwner)
+            {
+                pc_Buffer[u32_Offset] = '1';
+            }
+            else
+            {
+                pc_Buffer[u32_Offset] = '0';
+            }
+
+            /* Increment offset */
+            u32_Offset++;
+
+            /* Descend into left tree */
+            if (pt_Id->pt_Left)
+            {
+                /* Remember the parent address */
+                pt_CurrentIdParent = pt_Id;
+
+                pt_Id = pt_Id->pt_Left;
+            }
+            /* Valid parent ITC Id trees always have both left and right
+             * nodes. Thus, there is no need to check if the current node
+             * doesn't have a left child but has a right one.
+             *
+             * Instead directly start backtracking up the tree */
+            else
+            {
+                /* Loop until the current element is no longer reachable
+                 * through the parent's right child */
+                while (t_Status == ITC_STATUS_SUCCESS &&
+                       pt_CurrentIdParent != pt_RootIdParent &&
+                       pt_CurrentIdParent->pt_Right == pt_Id)
+                {
+                    pt_Id = pt_Id->pt_Parent;
+                    pt_CurrentIdParent = pt_CurrentIdParent->pt_Parent;
+
+                    /* Check there is space left in the buffer, taking into
+                     * account the NULL termination byte */
+                    if (u32_Offset >= (*pu32_BufferSize - 1))
+                    {
+                        t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;
+                    }
+                    else
+                    {
+                        /* Close the current parent node bracket */
+                        pc_Buffer[u32_Offset] = ')';
+                        u32_Offset++;
+                    }
+                }
+
+                /* There is a right subtree that has not been explored yet */
+                if (t_Status == ITC_STATUS_SUCCESS &&
+                    pt_CurrentIdParent != pt_RootIdParent)
+                {
+                    pt_Id = pt_CurrentIdParent->pt_Right;
+
+                    /* Check there is space left in the buffer, taking into
+                     * account the NULL termination byte */
+                    if (u32_Offset >= (*pu32_BufferSize - 1))
+                    {
+                        t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;
+                    }
+                    else
+                    {
+                        /* Add a comma to signify the start of a new node */
+                        pc_Buffer[u32_Offset] = ',';
+                        u32_Offset++;
+                    }
+
+                    /* Check there is space left in the buffer, taking into
+                     * account the NULL termination byte */
+                    if (u32_Offset >= (*pu32_BufferSize - 1))
+                    {
+                        t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;
+                    }
+                    else
+                    {
+                        /* Add a space between nodes */
+                        pc_Buffer[u32_Offset] = ' ';
+                        u32_Offset++;
+                    }
+                }
+                else
+                {
+                    pt_Id = NULL;
+                }
+            }
+        }
+    }
+
+    if (t_Status != ITC_STATUS_INVALID_PARAM)
+    {
+        /* Ensure the string is always NULL-termiated */
+        pc_Buffer[u32_Offset] = '\0';
+        u32_Offset++;
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        /* Return the size of the data in the buffer */
+        *pu32_BufferSize = u32_Offset;
+    }
+
+    return t_Status;
+}
+
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+
 /**
  * @brief Deserialise an ITC Id
  *
@@ -1472,7 +1626,7 @@ ITC_Status_t ITC_SerDes_Util_serialiseId(
     ITC_Status_t t_Status; /* The current status */
 
     t_Status = ITC_SerDes_Util_validateBuffer(
-        pu8_Buffer,
+        &pu8_Buffer[0],
         pu32_BufferSize,
         (b_AddVersion) ? ITC_SERDES_ID_MIN_BUFFER_LEN + ITC_VERSION_MAJOR_LEN
                        : ITC_SERDES_ID_MIN_BUFFER_LEN,
@@ -1486,7 +1640,7 @@ ITC_Status_t ITC_SerDes_Util_serialiseId(
     if (t_Status == ITC_STATUS_SUCCESS)
     {
         t_Status = serialiseId(
-            pt_Id, pu8_Buffer, pu32_BufferSize, b_AddVersion);
+            pt_Id, &pu8_Buffer[0], pu32_BufferSize, b_AddVersion);
     }
 
     return t_Status;
@@ -1513,7 +1667,7 @@ ITC_Status_t ITC_SerDes_Util_deserialiseId(
     if (t_Status == ITC_STATUS_SUCCESS)
     {
         t_Status = ITC_SerDes_Util_validateBuffer(
-            pu8_Buffer,
+            &pu8_Buffer[0],
             &u32_BufferSize,
             (b_HasVersion) ? ITC_SERDES_ID_MIN_BUFFER_LEN + ITC_VERSION_MAJOR_LEN
                            : ITC_SERDES_ID_MIN_BUFFER_LEN,
@@ -1523,11 +1677,47 @@ ITC_Status_t ITC_SerDes_Util_deserialiseId(
     if (t_Status == ITC_STATUS_SUCCESS)
     {
         t_Status = deserialiseId(
-            pu8_Buffer, u32_BufferSize, b_HasVersion, ppt_Id);
+            &pu8_Buffer[0], u32_BufferSize, b_HasVersion, ppt_Id);
     }
 
     return t_Status;
 }
+
+
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+
+/******************************************************************************
+ * Serialise an existing ITC Id to string
+ ******************************************************************************/
+
+ITC_Status_t ITC_SerDes_serialiseIdToString(
+    const ITC_Id_t *const pt_Id,
+    char *const pc_Buffer,
+    uint32_t *const pu32_BufferSize
+)
+{
+    ITC_Status_t t_Status; /* The current status */
+
+    t_Status = ITC_SerDes_Util_validateBuffer(
+        (uint8_t *)&pc_Buffer[0],
+        pu32_BufferSize,
+        ITC_SER_TO_STR_ID_MIN_BUFFER_LEN,
+        true);
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        t_Status = validateId(pt_Id, true);
+    }
+
+    if (t_Status == ITC_STATUS_SUCCESS)
+    {
+        t_Status = serialiseIdToString(pt_Id, &pc_Buffer[0], pu32_BufferSize);
+    }
+
+    return t_Status;
+}
+
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 
 #if ITC_CONFIG_ENABLE_EXTENDED_API
 

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -15,9 +15,9 @@
 #include "ITC_SerDes_private.h"
 #include "ITC_SerDes_Util_package.h"
 
-#if ITC_CONFIG_ENABLE_EXTENDED_API || ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_EXTENDED_API
 #include "ITC_SerDes.h"
-#endif /* ITC_CONFIG_ENABLE_EXTENDED_API || ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 
 #include "ITC_Port.h"
 
@@ -984,7 +984,7 @@ static ITC_Status_t serialiseId(
     return t_Status;
 }
 
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
 
 /**
  * @brief Serialise an existing ITC Id to ASCII string
@@ -1127,7 +1127,7 @@ static ITC_Status_t serialiseIdToString(
     return t_Status;
 }
 
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 
 /**
  * @brief Deserialise an ITC Id
@@ -1674,6 +1674,8 @@ ITC_Status_t ITC_SerDes_Util_deserialiseId(
     return t_Status;
 }
 
+#if ITC_CONFIG_ENABLE_EXTENDED_API
+
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 
 /******************************************************************************
@@ -1708,8 +1710,6 @@ ITC_Status_t ITC_SerDes_serialiseIdToString(
 }
 
 #endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
-
-#if ITC_CONFIG_ENABLE_EXTENDED_API
 
 /******************************************************************************
  * Serialise an existing ITC Id

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -987,7 +987,7 @@ static ITC_Status_t serialiseId(
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 
 /**
- * @brief Serialise an existing ITC Id to string
+ * @brief Serialise an existing ITC Id to ASCII string
  *
  * @param ppt_Id The pointer to the Id
  * @param pc_Buffer The buffer to hold the serialised data
@@ -1067,7 +1067,7 @@ static ITC_Status_t serialiseIdToString(
                     pt_CurrentIdParent = pt_CurrentIdParent->pt_Parent;
 
                     /* Check there is space left in the buffer, taking into
-                     * account the NULL termination byte */
+                     * account the NULL termination byte and bracket */
                     if (u32_Offset >= (*pu32_BufferSize - 1))
                     {
                         t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;
@@ -1088,7 +1088,7 @@ static ITC_Status_t serialiseIdToString(
 
                     /* Check there is space left in the buffer, taking into
                      * account the NULL termination byte, comma and space */
-                    if (u32_Offset >= (*pu32_BufferSize - 3))
+                    if (u32_Offset >= (*pu32_BufferSize - 2))
                     {
                         t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;
                     }

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -988,7 +988,7 @@ static ITC_Status_t serialiseId(
     return t_Status;
 }
 
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 
 /**
  * @brief Serialise an existing ITC Id to ASCII string
@@ -1131,7 +1131,7 @@ static ITC_Status_t serialiseIdToString(
     return t_Status;
 }
 
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 
 /**
  * @brief Deserialise an ITC Id

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -1087,8 +1087,8 @@ static ITC_Status_t serialiseIdToString(
                     pt_Id = pt_CurrentIdParent->pt_Right;
 
                     /* Check there is space left in the buffer, taking into
-                     * account the NULL termination byte */
-                    if (u32_Offset >= (*pu32_BufferSize - 1))
+                     * account the NULL termination byte, comma and space */
+                    if (u32_Offset >= (*pu32_BufferSize - 3))
                     {
                         t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;
                     }
@@ -1097,16 +1097,7 @@ static ITC_Status_t serialiseIdToString(
                         /* Add a comma to signify the start of a new node */
                         pc_Buffer[u32_Offset] = ',';
                         u32_Offset++;
-                    }
 
-                    /* Check there is space left in the buffer, taking into
-                     * account the NULL termination byte */
-                    if (u32_Offset >= (*pu32_BufferSize - 1))
-                    {
-                        t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;
-                    }
-                    else
-                    {
                         /* Add a space between nodes */
                         pc_Buffer[u32_Offset] = ' ';
                         u32_Offset++;
@@ -1682,7 +1673,6 @@ ITC_Status_t ITC_SerDes_Util_deserialiseId(
 
     return t_Status;
 }
-
 
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -19,6 +19,10 @@
 #include "ITC_SerDes.h"
 #endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 
+#if !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API)
+#include "ITC_SerDes_package.h"
+#endif /* !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API) */
+
 #include "ITC_Port.h"
 
 #include <stdbool.h>
@@ -1674,8 +1678,6 @@ ITC_Status_t ITC_SerDes_Util_deserialiseId(
     return t_Status;
 }
 
-#if ITC_CONFIG_ENABLE_EXTENDED_API
-
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 
 /******************************************************************************
@@ -1710,6 +1712,8 @@ ITC_Status_t ITC_SerDes_serialiseIdToString(
 }
 
 #endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+
+#if ITC_CONFIG_ENABLE_EXTENDED_API
 
 /******************************************************************************
  * Serialise an existing ITC Id

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -1012,9 +1012,9 @@ static ITC_Status_t serialiseIdToString(
     const ITC_Id_t *pt_RootIdParent = pt_Id->pt_Parent; /* The root parent */
     uint32_t u32_Offset = 0;
 
+    /* Ensure there is at least space for the NULL termination */
     if (*pu32_BufferSize < 1)
     {
-        /* Ensure there is at least space for the NULL termination */
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
 
@@ -1022,7 +1022,7 @@ static ITC_Status_t serialiseIdToString(
     while (t_Status == ITC_STATUS_SUCCESS && pt_Id)
     {
         /* Check there is space left in the buffer, taking into account the
-         * NULL termination byte */
+         * NULL termination byte and opening bracket/ownership indicator */
         if (u32_Offset >= (*pu32_BufferSize - 1))
         {
             t_Status = ITC_STATUS_INSUFFICIENT_RESOURCES;

--- a/libitc/ITC_SerDes_private.h
+++ b/libitc/ITC_SerDes_private.h
@@ -176,6 +176,13 @@
  * at least be NULL terminated. */
 #define ITC_SER_TO_STR_EVENT_MIN_BUFFER_LEN                                  (1)
 
+/* The minimum possible length of an Stamp serialisation (to string) string
+ * buffer - a NULL terminated buffer. Requires 1 byte for the NULL termination.
+ * Keeping the minimum length requirement to be just a NULL terminator ensures
+ * that even if the buffer is too small to hold any usable data, it will still
+ * at least be NULL terminated. */
+#define ITC_SER_TO_STR_STAMP_MIN_BUFFER_LEN                                  (1)
+
 /******************************************************************************
  * Types
  ******************************************************************************/

--- a/libitc/ITC_SerDes_private.h
+++ b/libitc/ITC_SerDes_private.h
@@ -162,6 +162,11 @@
         ITC_SERDES_STAMP_EVENT_COMPONENT_LEN_MASK,                             \
         ITC_SERDES_STAMP_EVENT_COMPONENT_LEN_OFFSET)
 
+/* The minimum possible length of an ID serialisation (to string) string buffer
+ * - one for a leaf ID - requires 1 byte to represent the ID and a NULL byte
+ * (`"1\0"`) or (`"0\0"`) */
+#define ITC_SER_TO_STR_ID_MIN_BUFFER_LEN                                     (2)
+
 /******************************************************************************
  * Types
  ******************************************************************************/

--- a/libitc/ITC_SerDes_private.h
+++ b/libitc/ITC_SerDes_private.h
@@ -169,6 +169,13 @@
  * NULL terminated. */
 #define ITC_SER_TO_STR_ID_MIN_BUFFER_LEN                                     (1)
 
+/* The minimum possible length of an Event serialisation (to string) string
+ * buffer - a NULL terminated buffer. Requires 1 byte for the NULL termination.
+ * Keeping the minimum length requirement to be just a NULL terminator ensures
+ * that even if the buffer is too small to hold any usable data, it will still
+ * at least be NULL terminated. */
+#define ITC_SER_TO_STR_EVENT_MIN_BUFFER_LEN                                  (1)
+
 /******************************************************************************
  * Types
  ******************************************************************************/

--- a/libitc/ITC_SerDes_private.h
+++ b/libitc/ITC_SerDes_private.h
@@ -163,9 +163,11 @@
         ITC_SERDES_STAMP_EVENT_COMPONENT_LEN_OFFSET)
 
 /* The minimum possible length of an ID serialisation (to string) string buffer
- * - one for a leaf ID - requires 1 byte to represent the ID and a NULL byte
- * (`"1\0"`) or (`"0\0"`) */
-#define ITC_SER_TO_STR_ID_MIN_BUFFER_LEN                                     (2)
+ * - a NULL terminated buffer. Requires 1 byte for the NULL termination. Keeping
+ * the minimum length requirement to be just a NULL terminator ensures that even
+ * if the buffer is too small to hold any usable data, it will still at least be
+ * NULL terminated. */
+#define ITC_SER_TO_STR_ID_MIN_BUFFER_LEN                                     (1)
 
 /******************************************************************************
  * Types

--- a/libitc/ITC_Stamp.c
+++ b/libitc/ITC_Stamp.c
@@ -8,9 +8,15 @@
  *
  */
 #include "ITC_Stamp.h"
+#include "ITC_config.h"
 #include "ITC_SerDes.h"
-#include "ITC_SerDes_private.h"
+
+#if !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API)
+#include "ITC_SerDes_package.h"
+#endif /* !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API) */
+
 #include "ITC_SerDes_Util_package.h"
+#include "ITC_SerDes_private.h"
 
 #include "ITC_Event_package.h"
 #include "ITC_Id_package.h"

--- a/libitc/include/ITC_Event.h
+++ b/libitc/include/ITC_Event.h
@@ -20,7 +20,7 @@ typedef uint64_t ITC_Event_Counter_t;
 #else
 /* The ITC Event counter */
 typedef uint32_t ITC_Event_Counter_t;
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
 
 /* The ITC Event */
 typedef struct ITC_Event_t

--- a/libitc/include/ITC_SerDes.h
+++ b/libitc/include/ITC_SerDes.h
@@ -170,7 +170,7 @@ ITC_Status_t ITC_SerDes_deserialiseStamp(
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 
 /**
- * @brief Serialise an existing ITC Id to string
+ * @brief Serialise an existing ITC Id to ASCII string
  *
  * @note The output buffer is always NULL-terminated
  * @param ppt_Id The pointer to the Id

--- a/libitc/include/ITC_SerDes.h
+++ b/libitc/include/ITC_SerDes.h
@@ -169,6 +169,8 @@ ITC_Status_t ITC_SerDes_deserialiseStamp(
 
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 
+#if ITC_CONFIG_ENABLE_EXTENDED_API
+
 /**
  * @brief Serialise an existing ITC Id to ASCII string
  *
@@ -204,6 +206,8 @@ ITC_Status_t ITC_SerDes_serialiseEventToString(
     char *const pc_Buffer,
     uint32_t *const pu32_BufferSize
 );
+
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 
 /**
  * @brief Serialise an existing ITC Stamp to ASCII string

--- a/libitc/include/ITC_SerDes.h
+++ b/libitc/include/ITC_SerDes.h
@@ -167,4 +167,26 @@ ITC_Status_t ITC_SerDes_deserialiseStamp(
     ITC_Stamp_t **ppt_Stamp
 );
 
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+
+/**
+ * @brief Serialise an existing ITC Id to string
+ *
+ * @note The output buffer is always NULL-terminated
+ * @param ppt_Id The pointer to the Id
+ * @param pc_Buffer The buffer to hold the serialised data
+ * @param pu32_BufferSize (in) The size of the buffer in bytes. (out) The size
+ * of the data inside the buffer in bytes (including the NULL termination byte).
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
+ * @retval `ITC_STATUS_INSUFFICIENT_RESOURCES` if the buffer is not big enough
+ */
+ITC_Status_t ITC_SerDes_serialiseIdToString(
+    const ITC_Id_t *const pt_Id,
+    char *const pc_Buffer,
+    uint32_t *const pu32_BufferSize
+);
+
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+
 #endif /* ITC_SERDES_H_ */

--- a/libitc/include/ITC_SerDes.h
+++ b/libitc/include/ITC_SerDes.h
@@ -205,6 +205,24 @@ ITC_Status_t ITC_SerDes_serialiseEventToString(
     uint32_t *const pu32_BufferSize
 );
 
+/**
+ * @brief Serialise an existing ITC Stamp to ASCII string
+ *
+ * @note The output buffer is always NULL-terminated
+ * @param ppt_Stamp The pointer to the Stamp
+ * @param pc_Buffer The buffer to hold the serialised data
+ * @param pu32_BufferSize (in) The size of the buffer in bytes. (out) The size
+ * of the data inside the buffer in bytes (including the NULL termination byte).
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
+ * @retval `ITC_STATUS_INSUFFICIENT_RESOURCES` if the buffer is not big enough
+ */
+ITC_Status_t ITC_SerDes_serialiseStampToString(
+    const ITC_Stamp_t *const pt_Stamp,
+    char *const pc_Buffer,
+    uint32_t *const pu32_BufferSize
+);
+
 #endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 
 #endif /* ITC_SERDES_H_ */

--- a/libitc/include/ITC_SerDes.h
+++ b/libitc/include/ITC_SerDes.h
@@ -187,6 +187,24 @@ ITC_Status_t ITC_SerDes_serialiseIdToString(
     uint32_t *const pu32_BufferSize
 );
 
+/**
+ * @brief Serialise an existing ITC Event to ASCII string
+ *
+ * @note The output buffer is always NULL-terminated
+ * @param ppt_Event The pointer to the Event
+ * @param pc_Buffer The buffer to hold the serialised data
+ * @param pu32_BufferSize (in) The size of the buffer in bytes. (out) The size
+ * of the data inside the buffer in bytes (including the NULL termination byte).
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
+ * @retval `ITC_STATUS_INSUFFICIENT_RESOURCES` if the buffer is not big enough
+ */
+ITC_Status_t ITC_SerDes_serialiseEventToString(
+    const ITC_Event_t *const pt_Event,
+    char *const pc_Buffer,
+    uint32_t *const pu32_BufferSize
+);
+
 #endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 
 #endif /* ITC_SERDES_H_ */

--- a/libitc/include/ITC_config.h
+++ b/libitc/include/ITC_config.h
@@ -55,9 +55,11 @@
 
 #ifndef ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 /** Enabling this setting gives access to a few additional API calls,
- * which can be used to get an ASCII encodded representation of an ID. When
- * enabled, the following functions become available as part of the public API:
+ * which can be used to get an ASCII encodded representation of an ID or Event.
+ * When enabled, the following functions become available as part of
+ * the public API:
  *   * `ITC_SerDes_serialiseIdToString`
+ *   * `ITC_SerDes_serialiseEventToString`
  */
 #define ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API                            (1)
 #endif

--- a/libitc/include/ITC_config.h
+++ b/libitc/include/ITC_config.h
@@ -50,7 +50,16 @@
  *   * `ITC_Stamp_setId`
  *   * `ITC_Stamp_setEvent`
  */
-#define ITC_CONFIG_ENABLE_EXTENDED_API                                       (0)
+#define ITC_CONFIG_ENABLE_EXTENDED_API                                       (1)
+#endif
+
+#ifndef ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+/** Enabling this setting gives access to a few additional API calls,
+ * which can be used to get an ASCII encodded representation of an ID. When
+ * enabled, the following functions become available as part of the public API:
+ *   * `ITC_SerDes_serialiseIdToString`
+ */
+#define ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API                            (1)
 #endif
 
 #endif /* ITC_CONFIG_H_ */

--- a/libitc/include/ITC_config.h
+++ b/libitc/include/ITC_config.h
@@ -55,11 +55,12 @@
 
 #ifndef ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 /** Enabling this setting gives access to a few additional API calls,
- * which can be used to get an ASCII encodded representation of an ID or Event.
- * When enabled, the following functions become available as part of
+ * which can be used to get an ASCII encodded representation of an ID, Event
+ * or Stamp. When enabled, the following functions become available as part of
  * the public API:
  *   * `ITC_SerDes_serialiseIdToString`
  *   * `ITC_SerDes_serialiseEventToString`
+ *   * `ITC_SerDes_serialiseStampToString`
  */
 #define ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API                            (1)
 #endif

--- a/libitc/include/ITC_config.h
+++ b/libitc/include/ITC_config.h
@@ -58,9 +58,11 @@
  * which can be used to get an ASCII encodded representation of an ID, Event
  * or Stamp. When enabled, the following functions become available as part of
  * the public API:
- *   * `ITC_SerDes_serialiseIdToString`
- *   * `ITC_SerDes_serialiseEventToString`
  *   * `ITC_SerDes_serialiseStampToString`
+ *   * `ITC_SerDes_serialiseIdToString` (requires
+ *          `ITC_CONFIG_ENABLE_EXTENDED_API` to also be enabled)
+ *   * `ITC_SerDes_serialiseEventToString` (requires
+ *          `ITC_CONFIG_ENABLE_EXTENDED_API` to also be enabled)
  */
 #define ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API                            (0)
 #endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */

--- a/libitc/include/ITC_config.h
+++ b/libitc/include/ITC_config.h
@@ -50,7 +50,7 @@
  *   * `ITC_Stamp_setId`
  *   * `ITC_Stamp_setEvent`
  */
-#define ITC_CONFIG_ENABLE_EXTENDED_API                                       (1)
+#define ITC_CONFIG_ENABLE_EXTENDED_API                                       (0)
 #endif
 
 #ifndef ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
@@ -62,7 +62,7 @@
  *   * `ITC_SerDes_serialiseEventToString`
  *   * `ITC_SerDes_serialiseStampToString`
  */
-#define ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API                            (1)
+#define ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API                            (0)
 #endif
 
 #endif /* ITC_CONFIG_H_ */

--- a/libitc/include/ITC_config.h
+++ b/libitc/include/ITC_config.h
@@ -55,7 +55,7 @@
 
 #ifndef ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 /** Enabling this setting gives access to a few additional API calls,
- * which can be used to get an ASCII encodded representation of an ID, Event
+ * which can be used to get an ASCII encoded representation of an ID, Event
  * or Stamp. When enabled, the following functions become available as part of
  * the public API:
  *   * `ITC_SerDes_serialiseStampToString`

--- a/libitc/include/ITC_config.h
+++ b/libitc/include/ITC_config.h
@@ -19,7 +19,7 @@
  *   happens every nanosecond, this counter will saturate in about 584.5 years.
 */
 #define ITC_CONFIG_USE_64BIT_EVENT_COUNTERS                                  (0)
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
 
 #ifndef ITC_CONFIG_ENABLE_EXTENDED_API
 /** Enabling this setting gives access to a few additional API calls,
@@ -51,7 +51,7 @@
  *   * `ITC_Stamp_setEvent`
  */
 #define ITC_CONFIG_ENABLE_EXTENDED_API                                       (0)
-#endif
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 
 #ifndef ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
 /** Enabling this setting gives access to a few additional API calls,
@@ -63,6 +63,6 @@
  *   * `ITC_SerDes_serialiseStampToString`
  */
 #define ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API                            (0)
-#endif
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 
 #endif /* ITC_CONFIG_H_ */

--- a/libitc/package-include/ITC_SerDes_package.h
+++ b/libitc/package-include/ITC_SerDes_package.h
@@ -1,0 +1,67 @@
+/**
+ * @file ITC_SerDes_package.h
+ * @brief Package definitions for the Interval Tree Clock's serialisation and
+ * deserialisation mechanism
+ *
+ * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0
+ * license. Refer to the LICENSE file for details or visit:
+ * https://www.gnu.org/licenses/agpl-3.0.en.html
+ *
+ */
+#ifndef ITC_SERDES_PACKAGE_H_
+#define ITC_SERDES_PACKAGE_H_
+
+#include "ITC_Status.h"
+#include "ITC_config.h"
+
+#if !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API)
+#include "ITC_Id.h"
+#include "ITC_Event.h"
+#endif /* !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API) */
+
+
+/******************************************************************************
+ * Functions
+ ******************************************************************************/
+
+#if !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API)
+
+/**
+ * @brief Serialise an existing ITC Id to ASCII string
+ *
+ * @note The output buffer is always NULL-terminated
+ * @param ppt_Id The pointer to the Id
+ * @param pc_Buffer The buffer to hold the serialised data
+ * @param pu32_BufferSize (in) The size of the buffer in bytes. (out) The size
+ * of the data inside the buffer in bytes (including the NULL termination byte).
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
+ * @retval `ITC_STATUS_INSUFFICIENT_RESOURCES` if the buffer is not big enough
+ */
+ITC_Status_t ITC_SerDes_serialiseIdToString(
+    const ITC_Id_t *const pt_Id,
+    char *const pc_Buffer,
+    uint32_t *const pu32_BufferSize
+);
+
+/**
+ * @brief Serialise an existing ITC Event to ASCII string
+ *
+ * @note The output buffer is always NULL-terminated
+ * @param ppt_Event The pointer to the Event
+ * @param pc_Buffer The buffer to hold the serialised data
+ * @param pu32_BufferSize (in) The size of the buffer in bytes. (out) The size
+ * of the data inside the buffer in bytes (including the NULL termination byte).
+ * @return `ITC_Status_t` The status of the operation
+ * @retval `ITC_STATUS_SUCCESS` on success
+ * @retval `ITC_STATUS_INSUFFICIENT_RESOURCES` if the buffer is not big enough
+ */
+ITC_Status_t ITC_SerDes_serialiseEventToString(
+    const ITC_Event_t *const pt_Event,
+    char *const pc_Buffer,
+    uint32_t *const pu32_BufferSize
+);
+
+#endif /* !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API) */
+
+#endif /* ITC_SERDES_PACKAGE_H_ */

--- a/libitc/test/include/ITC_SerDes_Test_package.h
+++ b/libitc/test/include/ITC_SerDes_Test_package.h
@@ -143,6 +143,11 @@
    ITC_SERDES_STAMP_SET_EVENT_COMPONENT_LEN_LEN(                               \
         (ITC_SerDes_Header_t)0U, u8_LenEvent))
 
+/* The minimum possible length of an ID serialisation (to string) string buffer
+ * - one for a leaf ID - requires 1 byte to represent the ID and a NULL byte
+ * (`"1\0"`) or (`"0\0"`) */
+#define ITC_SER_TO_STR_ID_MIN_BUFFER_LEN                                     (2)
+
 /******************************************************************************
  * Types
  ******************************************************************************/

--- a/libitc/test/include/ITC_SerDes_Test_package.h
+++ b/libitc/test/include/ITC_SerDes_Test_package.h
@@ -150,6 +150,13 @@
  * NULL terminated. */
 #define ITC_SER_TO_STR_ID_MIN_BUFFER_LEN                                     (1)
 
+/* The minimum possible length of an Event serialisation (to string) string
+ * buffer - a NULL terminated buffer. Requires 1 byte for the NULL termination.
+ * Keeping the minimum length requirement to be just a NULL terminator ensures
+ * that even if the buffer is too small to hold any usable data, it will still
+ * at least be NULL terminated. */
+#define ITC_SER_TO_STR_EVENT_MIN_BUFFER_LEN                                  (1)
+
 /******************************************************************************
  * Types
  ******************************************************************************/

--- a/libitc/test/include/ITC_SerDes_Test_package.h
+++ b/libitc/test/include/ITC_SerDes_Test_package.h
@@ -157,6 +157,13 @@
  * at least be NULL terminated. */
 #define ITC_SER_TO_STR_EVENT_MIN_BUFFER_LEN                                  (1)
 
+/* The minimum possible length of an Stamp serialisation (to string) string
+ * buffer - a NULL terminated buffer. Requires 1 byte for the NULL termination.
+ * Keeping the minimum length requirement to be just a NULL terminator ensures
+ * that even if the buffer is too small to hold any usable data, it will still
+ * at least be NULL terminated. */
+#define ITC_SER_TO_STR_STAMP_MIN_BUFFER_LEN                                  (1)
+
 /******************************************************************************
  * Types
  ******************************************************************************/

--- a/libitc/test/include/ITC_SerDes_Test_package.h
+++ b/libitc/test/include/ITC_SerDes_Test_package.h
@@ -144,9 +144,11 @@
         (ITC_SerDes_Header_t)0U, u8_LenEvent))
 
 /* The minimum possible length of an ID serialisation (to string) string buffer
- * - one for a leaf ID - requires 1 byte to represent the ID and a NULL byte
- * (`"1\0"`) or (`"0\0"`) */
-#define ITC_SER_TO_STR_ID_MIN_BUFFER_LEN                                     (2)
+ * - a NULL terminated buffer. Requires 1 byte for the NULL termination. Keeping
+ * the minimum length requirement to be just a NULL terminator ensures that even
+ * if the buffer is too small to hold any usable data, it will still at least be
+ * NULL terminated. */
+#define ITC_SER_TO_STR_ID_MIN_BUFFER_LEN                                     (1)
 
 /******************************************************************************
  * Types

--- a/libitc/test/normal/ITC_SerDes_Test.c
+++ b/libitc/test/normal/ITC_SerDes_Test.c
@@ -265,7 +265,7 @@ void ITC_SerDes_Test_serialiseIdParentSuccessful(void)
 /* Test serialising a Id to string fails with invalid param */
 void ITC_SerDes_Test_serialiseIdToStringFailInvalidParam(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Id_t *pt_Dummy = NULL;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -298,13 +298,13 @@ void ITC_SerDes_Test_serialiseIdToStringFailInvalidParam(void)
         ITC_STATUS_INVALID_PARAM);
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising an ID to string fails with corrupt ID */
 void ITC_SerDes_Test_serialiseToStringIdFailWithCorruptId(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Id_t *pt_Id;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -330,13 +330,13 @@ void ITC_SerDes_Test_serialiseToStringIdFailWithCorruptId(void)
     }
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising a leaf ID to string succeeds */
 void ITC_SerDes_Test_serialiseIdLeafToStringSuccessful(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[2];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -390,13 +390,13 @@ void ITC_SerDes_Test_serialiseIdLeafToStringSuccessful(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising an ID to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseIdToStringFailWithInsufficentResources(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[ITC_SER_TO_STR_ID_MIN_BUFFER_LEN];
     uint32_t u32_BufferSize;
@@ -426,13 +426,13 @@ void ITC_SerDes_Test_serialiseIdToStringFailWithInsufficentResources(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising a parent ID to string succeeds */
 void ITC_SerDes_Test_serialiseIdParentToStringSuccessful(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[22];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -473,13 +473,13 @@ void ITC_SerDes_Test_serialiseIdParentToStringSuccessful(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising a parent ID to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseIdParentToStringFailWithInsufficentResources(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[21];
     uint32_t u32_BufferSize;
@@ -533,7 +533,7 @@ void ITC_SerDes_Test_serialiseIdParentToStringFailWithInsufficentResources(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test deserialising a ID fails with invalid param */
@@ -941,7 +941,7 @@ void ITC_SerDes_Test_serialiseEventParentSuccessful(void)
 /* Test serialising a Event to string fails with invalid param */
 void ITC_SerDes_Test_serialiseEventToStringFailInvalidParam(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Event_t *pt_Dummy = NULL;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -974,13 +974,13 @@ void ITC_SerDes_Test_serialiseEventToStringFailInvalidParam(void)
         ITC_STATUS_INVALID_PARAM);
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising an Event to string fails with corrupt Event */
 void ITC_SerDes_Test_serialiseToStringEventFailWithCorruptEvent(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Event_t *pt_Event;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -1006,13 +1006,13 @@ void ITC_SerDes_Test_serialiseToStringEventFailWithCorruptEvent(void)
     }
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising a leaf Event to string succeeds */
 void ITC_SerDes_Test_serialiseEventLeafToStringSuccessful(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Event_t *pt_Event = NULL;
     char rc_Buffer[3];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -1072,13 +1072,13 @@ void ITC_SerDes_Test_serialiseEventLeafToStringSuccessful(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising an Event to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseEventToStringFailWithInsufficentResources(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Event_t *pt_Event = NULL;
     char rc_Buffer[ITC_SER_TO_STR_EVENT_MIN_BUFFER_LEN];
     uint32_t u32_BufferSize;
@@ -1108,13 +1108,13 @@ void ITC_SerDes_Test_serialiseEventToStringFailWithInsufficentResources(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising a parent Event to string succeeds */
 void ITC_SerDes_Test_serialiseEventParentToStringSuccessful(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Event_t *pt_Event = NULL;
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     char rc_Buffer[48];
@@ -1165,13 +1165,13 @@ void ITC_SerDes_Test_serialiseEventParentToStringSuccessful(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test serialising a parent Event to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseEventParentToStringFailWithInsufficentResources(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Event_t *pt_Event = NULL;
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     char rc_Buffer[47];
@@ -1234,7 +1234,7 @@ void ITC_SerDes_Test_serialiseEventParentToStringFailWithInsufficentResources(vo
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test deserialising an Event fails with invalid param */

--- a/libitc/test/normal/ITC_SerDes_Test.c
+++ b/libitc/test/normal/ITC_SerDes_Test.c
@@ -306,7 +306,7 @@ void ITC_SerDes_Test_serialiseIdToStringFailInvalidParam(void)
 }
 
 /* Test serialising an ID to string fails with corrupt ID */
-void ITC_SerDes_Test_serialiseToStringIdFailWithCorruptId(void)
+void ITC_SerDes_Test_serialiseIdToStringFailWithCorruptId(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id;
@@ -338,7 +338,7 @@ void ITC_SerDes_Test_serialiseToStringIdFailWithCorruptId(void)
 }
 
 /* Test serialising a leaf ID to string succeeds */
-void ITC_SerDes_Test_serialiseIdLeafToStringSuccessful(void)
+void ITC_SerDes_Test_serialiseIdToStringLeafSuccessful(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
@@ -434,7 +434,7 @@ void ITC_SerDes_Test_serialiseIdToStringFailWithInsufficentResources(void)
 }
 
 /* Test serialising a parent ID to string succeeds */
-void ITC_SerDes_Test_serialiseIdParentToStringSuccessful(void)
+void ITC_SerDes_Test_serialiseIdToStringParentSuccessful(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
@@ -481,7 +481,7 @@ void ITC_SerDes_Test_serialiseIdParentToStringSuccessful(void)
 }
 
 /* Test serialising a parent ID to string fails with insufficent resources */
-void ITC_SerDes_Test_serialiseIdParentToStringFailWithInsufficentResources(void)
+void ITC_SerDes_Test_serialiseIdToStringParentFailWithInsufficentResources(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
@@ -982,7 +982,7 @@ void ITC_SerDes_Test_serialiseEventToStringFailInvalidParam(void)
 }
 
 /* Test serialising an Event to string fails with corrupt Event */
-void ITC_SerDes_Test_serialiseToStringEventFailWithCorruptEvent(void)
+void ITC_SerDes_Test_serialiseEventToStringFailWithCorruptEvent(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event;
@@ -1014,7 +1014,7 @@ void ITC_SerDes_Test_serialiseToStringEventFailWithCorruptEvent(void)
 }
 
 /* Test serialising a leaf Event to string succeeds */
-void ITC_SerDes_Test_serialiseEventLeafToStringSuccessful(void)
+void ITC_SerDes_Test_serialiseEventToStringLeafSuccessful(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
@@ -1116,7 +1116,7 @@ void ITC_SerDes_Test_serialiseEventToStringFailWithInsufficentResources(void)
 }
 
 /* Test serialising a parent Event to string succeeds */
-void ITC_SerDes_Test_serialiseEventParentToStringSuccessful(void)
+void ITC_SerDes_Test_serialiseEventToStringParentSuccessful(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
@@ -1173,7 +1173,7 @@ void ITC_SerDes_Test_serialiseEventParentToStringSuccessful(void)
 }
 
 /* Test serialising a parent Event to string fails with insufficent resources */
-void ITC_SerDes_Test_serialiseEventParentToStringFailWithInsufficentResources(void)
+void ITC_SerDes_Test_serialiseEventToStringParentFailWithInsufficentResources(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
@@ -1721,8 +1721,8 @@ void ITC_SerDes_Test_serialiseStampToStringFailInvalidParam(void)
 #endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
-/* Test serialising an Stamp to string fails with corrupt Stamp */
-void ITC_SerDes_Test_serialiseToStringStampFailWithCorruptStamp(void)
+/* Test serialising a Stamp to string fails with corrupt Stamp */
+void ITC_SerDes_Test_serialiseStampToStringFailWithCorruptStamp(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Stamp;
@@ -1754,7 +1754,7 @@ void ITC_SerDes_Test_serialiseToStringStampFailWithCorruptStamp(void)
 }
 
 /* Test serialising a Stamp with leaf ID and Event to string succeeds */
-void ITC_SerDes_Test_serialiseStampWithLeafIdAndEventToStringSuccessful(void)
+void ITC_SerDes_Test_serialiseStampToStringWithLeafIdAndEventSuccessful(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Stamp = NULL;
@@ -1816,7 +1816,7 @@ void ITC_SerDes_Test_serialiseStampWithLeafIdAndEventToStringSuccessful(void)
 #endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
-/* Test serialising an Stamp to string fails with insufficent resources */
+/* Test serialising a Stamp to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseStampToStringFailWithInsufficentResources(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
@@ -1853,7 +1853,7 @@ void ITC_SerDes_Test_serialiseStampToStringFailWithInsufficentResources(void)
 }
 
 /* Test serialising a Stamp with parent components to string succeeds */
-void ITC_SerDes_Test_serialiseStampWithParentComponentsToStringSuccessful(void)
+void ITC_SerDes_Test_serialiseStampToStringWithParentComponentsSuccessful(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Stamp = NULL;
@@ -1914,7 +1914,7 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsToStringSuccessful(void)
 
 /* Test serialising a Stamp with parent components to string fails with
  * insufficent resources */
-void ITC_SerDes_Test_serialiseStampWithParentComponentsToStringFailWithInsufficentResources(void)
+void ITC_SerDes_Test_serialiseStampToStringWithParentComponentsFailWithInsufficentResources(void)
 {
 #if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Stamp = NULL;
@@ -2018,7 +2018,7 @@ void ITC_SerDes_Test_deserialiseStampFailInvalidParam(void)
         ITC_STATUS_INVALID_PARAM);
 }
 
-/* Test deserialising an Stamp fails with corrupt Stamp */
+/* Test deserialising a Stamp fails with corrupt Stamp */
 void ITC_SerDes_Test_deserialiseStampFailWithCorruptStamp(void)
 {
     ITC_Stamp_t *pt_Stamp;

--- a/libitc/test/normal/ITC_SerDes_Test.c
+++ b/libitc/test/normal/ITC_SerDes_Test.c
@@ -265,6 +265,7 @@ void ITC_SerDes_Test_serialiseIdParentSuccessful(void)
 /* Test serialising a Id to string fails with invalid param */
 void ITC_SerDes_Test_serialiseIdToStringFailInvalidParam(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Dummy = NULL;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -295,11 +296,15 @@ void ITC_SerDes_Test_serialiseIdToStringFailInvalidParam(void)
             rc_Buffer,
             &u32_BufferSize),
         ITC_STATUS_INVALID_PARAM);
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an ID to string fails with corrupt ID */
 void ITC_SerDes_Test_serialiseToStringIdFailWithCorruptId(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -323,11 +328,15 @@ void ITC_SerDes_Test_serialiseToStringIdFailWithCorruptId(void)
         /* Destroy the ID */
         gpv_InvalidIdDestructorTable[u32_I](&pt_Id);
     }
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a leaf ID to string succeeds */
 void ITC_SerDes_Test_serialiseIdLeafToStringSuccessful(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[2];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -379,11 +388,15 @@ void ITC_SerDes_Test_serialiseIdLeafToStringSuccessful(void)
 
     /* Destroy the ID */
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an ID to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseIdToStringFailWithInsufficentResources(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[ITC_SER_TO_STR_ID_MIN_BUFFER_LEN];
     uint32_t u32_BufferSize;
@@ -411,11 +424,15 @@ void ITC_SerDes_Test_serialiseIdToStringFailWithInsufficentResources(void)
         rc_Buffer[ITC_SER_TO_STR_ID_MIN_BUFFER_LEN - 1]);
 
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a parent ID to string succeeds */
 void ITC_SerDes_Test_serialiseIdParentToStringSuccessful(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[22];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -454,11 +471,15 @@ void ITC_SerDes_Test_serialiseIdParentToStringSuccessful(void)
 
     /* Destroy the ID */
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a parent ID to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseIdParentToStringFailWithInsufficentResources(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[21];
     uint32_t u32_BufferSize;
@@ -510,6 +531,9 @@ void ITC_SerDes_Test_serialiseIdParentToStringFailWithInsufficentResources(void)
     }
 
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test deserialising a ID fails with invalid param */
@@ -846,7 +870,7 @@ void ITC_SerDes_Test_serialiseEventParentSuccessful(void)
     uint8_t ru8_Buffer[19] = { 0 };
 #else
     uint8_t ru8_Buffer[15] = { 0 };
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     uint32_t u32_BufferSize = sizeof(ru8_Buffer);
 
     /* Serialised (0, 1, (0, (4242, 0, UINT32_MAX/UINT64_MAX), 0)) Event */
@@ -876,7 +900,7 @@ void ITC_SerDes_Test_serialiseEventParentSuccessful(void)
         0xFFU,
         0xFFU,
         0xFFU,
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
         ITC_SERDES_CREATE_EVENT_HEADER(false, 0),
     };
 
@@ -891,7 +915,7 @@ void ITC_SerDes_Test_serialiseEventParentSuccessful(void)
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Left->pt_Right, pt_Event->pt_Right->pt_Left, UINT64_MAX));
 #else
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Left->pt_Right, pt_Event->pt_Right->pt_Left, UINT32_MAX));
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Right, pt_Event->pt_Right, 0));
     /* clang-format on */
 
@@ -917,6 +941,7 @@ void ITC_SerDes_Test_serialiseEventParentSuccessful(void)
 /* Test serialising a Event to string fails with invalid param */
 void ITC_SerDes_Test_serialiseEventToStringFailInvalidParam(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Dummy = NULL;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -947,11 +972,15 @@ void ITC_SerDes_Test_serialiseEventToStringFailInvalidParam(void)
             rc_Buffer,
             &u32_BufferSize),
         ITC_STATUS_INVALID_PARAM);
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an Event to string fails with corrupt Event */
 void ITC_SerDes_Test_serialiseToStringEventFailWithCorruptEvent(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -975,11 +1004,15 @@ void ITC_SerDes_Test_serialiseToStringEventFailWithCorruptEvent(void)
         /* Destroy the Event */
         gpv_InvalidEventDestructorTable[u32_I](&pt_Event);
     }
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a leaf Event to string succeeds */
 void ITC_SerDes_Test_serialiseEventLeafToStringSuccessful(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
     char rc_Buffer[3];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -1037,11 +1070,15 @@ void ITC_SerDes_Test_serialiseEventLeafToStringSuccessful(void)
 
     /* Destroy the Event */
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an Event to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseEventToStringFailWithInsufficentResources(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
     char rc_Buffer[ITC_SER_TO_STR_EVENT_MIN_BUFFER_LEN];
     uint32_t u32_BufferSize;
@@ -1069,24 +1106,28 @@ void ITC_SerDes_Test_serialiseEventToStringFailWithInsufficentResources(void)
         rc_Buffer[ITC_SER_TO_STR_EVENT_MIN_BUFFER_LEN - 1]);
 
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a parent Event to string succeeds */
 void ITC_SerDes_Test_serialiseEventParentToStringSuccessful(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     char rc_Buffer[48];
 #else
     char rc_Buffer[38];
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
 
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     const char *z_ExpectedEventSerialisedData = "(0, 1, (0, (4242, 0, 18446744073709551615), 0))";
 #else
     const char *z_ExpectedEventSerialisedData = "(0, 1, (0, (4242, 0, 4294967295), 0))";
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
 
     /* Init to a random value */
     memset(&rc_Buffer[0], 0xAA, sizeof(rc_Buffer));
@@ -1102,7 +1143,7 @@ void ITC_SerDes_Test_serialiseEventParentToStringSuccessful(void)
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Left->pt_Right, pt_Event->pt_Right->pt_Left, UINT64_MAX));
 #else
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Left->pt_Right, pt_Event->pt_Right->pt_Left, UINT32_MAX));
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Right, pt_Event->pt_Right, 0));
     /* clang-format on */
 
@@ -1122,24 +1163,28 @@ void ITC_SerDes_Test_serialiseEventParentToStringSuccessful(void)
 
     /* Destroy the Event */
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a parent Event to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseEventParentToStringFailWithInsufficentResources(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     char rc_Buffer[47];
 #else
     char rc_Buffer[37];
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
 
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     const char *z_ExpectedEventSerialisedData = "(0, 1, (0, (4242, 0, 18446744073709551615), 0))";
 #else
     const char *z_ExpectedEventSerialisedData = "(0, 1, (0, (4242, 0, 4294967295), 0))";
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
 
     /* clang-format off */
     /* Create a new (0, 1, (0, (4242, 0, UINT32_MAX/UINT64_MAX), 0)) Event */
@@ -1152,7 +1197,7 @@ void ITC_SerDes_Test_serialiseEventParentToStringFailWithInsufficentResources(vo
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Left->pt_Right, pt_Event->pt_Right->pt_Left, UINT64_MAX));
 #else
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Left->pt_Right, pt_Event->pt_Right->pt_Left, UINT32_MAX));
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Event->pt_Right->pt_Right, pt_Event->pt_Right, 0));
     /* clang-format on */
 
@@ -1187,6 +1232,9 @@ void ITC_SerDes_Test_serialiseEventParentToStringFailWithInsufficentResources(vo
     }
 
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test deserialising an Event fails with invalid param */
@@ -1381,7 +1429,7 @@ void ITC_SerDes_Test_deserialiseParentEventSuccessful(void)
         0xFFU,
         0xFFU,
         0xFFU,
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
         ITC_SERDES_CREATE_EVENT_HEADER(false, 0),
     };
     uint32_t u32_BufferSize = sizeof(ru8_Buffer);
@@ -1405,7 +1453,7 @@ void ITC_SerDes_Test_deserialiseParentEventSuccessful(void)
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right->pt_Left->pt_Right, UINT64_MAX);
 #else
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right->pt_Left->pt_Right, UINT32_MAX);
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Event->pt_Right->pt_Right, 0);
     /* clang-format on */
 
@@ -1561,7 +1609,7 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsSuccessful(void)
     uint8_t ru8_Buffer[18] = { 0 };
 #else
     uint8_t ru8_Buffer[14] = { 0 };
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     uint32_t u32_BufferSize = sizeof(ru8_Buffer);
 
     uint8_t ru8_ExpectedStampSerialisedData[] = {
@@ -1575,7 +1623,7 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsSuccessful(void)
         11,
 #else
         7,
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
         ITC_SERDES_CREATE_EVENT_HEADER(true, 0),
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
         ITC_SERDES_CREATE_EVENT_HEADER(false, 8),
@@ -1593,7 +1641,7 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsSuccessful(void)
         0xFFU,
         0xFFU,
         0xFFU,
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
         ITC_SERDES_CREATE_EVENT_HEADER(false, 0),
     };
 
@@ -1611,7 +1659,7 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsSuccessful(void)
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Stamp->pt_Event->pt_Left, pt_Stamp->pt_Event, UINT64_MAX));
 #else
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Stamp->pt_Event->pt_Left, pt_Stamp->pt_Event, UINT32_MAX));
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Stamp->pt_Event->pt_Right, pt_Stamp->pt_Event, 0));
     /* clang-format on */
 
@@ -1633,6 +1681,7 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsSuccessful(void)
 /* Test serialising a Stamp to string fails with invalid param */
 void ITC_SerDes_Test_serialiseStampToStringFailInvalidParam(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Dummy = NULL;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -1663,11 +1712,15 @@ void ITC_SerDes_Test_serialiseStampToStringFailInvalidParam(void)
             rc_Buffer,
             &u32_BufferSize),
         ITC_STATUS_INVALID_PARAM);
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an Stamp to string fails with corrupt Stamp */
 void ITC_SerDes_Test_serialiseToStringStampFailWithCorruptStamp(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Stamp;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -1691,11 +1744,15 @@ void ITC_SerDes_Test_serialiseToStringStampFailWithCorruptStamp(void)
         /* Destroy the Stamp */
         gpv_InvalidStampDestructorTable[u32_I](&pt_Stamp);
     }
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a Stamp with leaf ID and Event to string succeeds */
 void ITC_SerDes_Test_serialiseStampWithLeafIdAndEventToStringSuccessful(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Stamp = NULL;
     char rc_Buffer[8];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -1750,11 +1807,15 @@ void ITC_SerDes_Test_serialiseStampWithLeafIdAndEventToStringSuccessful(void)
 
     /* Destroy the Stamp */
     TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an Stamp to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseStampToStringFailWithInsufficentResources(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Stamp = NULL;
     char rc_Buffer[ITC_SER_TO_STR_STAMP_MIN_BUFFER_LEN];
     uint32_t u32_BufferSize;
@@ -1782,24 +1843,28 @@ void ITC_SerDes_Test_serialiseStampToStringFailWithInsufficentResources(void)
         rc_Buffer[ITC_SER_TO_STR_STAMP_MIN_BUFFER_LEN - 1]);
 
     TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a Stamp with parent components to string succeeds */
 void ITC_SerDes_Test_serialiseStampWithParentComponentsToStringSuccessful(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Stamp = NULL;
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     char rc_Buffer[39];
 #else
     char rc_Buffer[29];
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
 
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     const char *z_ExpectedStampSerialisedData = "{(1, 0); (0, 18446744073709551615, 0)}";
 #else
     const char *z_ExpectedStampSerialisedData = "{(1, 0); (0, 4294967295, 0)}";
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
 
     /* Init to a random value */
     memset(&rc_Buffer[0], 0xAA, sizeof(rc_Buffer));
@@ -1818,7 +1883,7 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsToStringSuccessful(void)
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Stamp->pt_Event->pt_Left, pt_Stamp->pt_Event, UINT64_MAX));
 #else
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Stamp->pt_Event->pt_Left, pt_Stamp->pt_Event, UINT32_MAX));
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Stamp->pt_Event->pt_Right, pt_Stamp->pt_Event, 0));
     /* clang-format on */
 
@@ -1838,25 +1903,29 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsToStringSuccessful(void)
 
     /* Destroy the Stamp */
     TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a Stamp with parent components to string fails with
  * insufficent resources */
 void ITC_SerDes_Test_serialiseStampWithParentComponentsToStringFailWithInsufficentResources(void)
 {
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Stamp_t *pt_Stamp = NULL;
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     char rc_Buffer[38];
 #else
     char rc_Buffer[28];
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
 
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     const char *z_ExpectedStampSerialisedData = "{(1, 0); (0, 18446744073709551615, 0)}";
 #else
     const char *z_ExpectedStampSerialisedData = "{(1, 0); (0, 4294967295, 0)}";
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
 
     /* Create a new Stamp */
     TEST_SUCCESS(ITC_Stamp_newSeed(&pt_Stamp));
@@ -1872,7 +1941,7 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsToStringFailWithInsuffice
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Stamp->pt_Event->pt_Left, pt_Stamp->pt_Event, UINT64_MAX));
 #else
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Stamp->pt_Event->pt_Left, pt_Stamp->pt_Event, UINT32_MAX));
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     TEST_SUCCESS(ITC_TestUtil_newEvent(&pt_Stamp->pt_Event->pt_Right, pt_Stamp->pt_Event, 0));
     /* clang-format on */
 
@@ -1907,6 +1976,9 @@ void ITC_SerDes_Test_serialiseStampWithParentComponentsToStringFailWithInsuffice
     }
 
     TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp));
+#else
+    TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test deserialising a Stamp fails with invalid param */
@@ -2099,7 +2171,7 @@ void ITC_SerDes_Test_deserialiseParentStampSuccessful(void)
         18,
 #else
         14,
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
         ITC_SERDES_CREATE_EVENT_HEADER(true, 0),
         ITC_SERDES_CREATE_EVENT_HEADER(false, 1),
         1,
@@ -2124,7 +2196,7 @@ void ITC_SerDes_Test_deserialiseParentStampSuccessful(void)
         0xFFU,
         0xFFU,
         0xFFU,
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
         ITC_SERDES_CREATE_EVENT_HEADER(false, 0),
     };
     uint32_t u32_BufferSize = sizeof(ru8_Buffer);
@@ -2148,7 +2220,7 @@ void ITC_SerDes_Test_deserialiseParentStampSuccessful(void)
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp->pt_Event->pt_Right->pt_Left->pt_Right, UINT64_MAX);
 #else
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp->pt_Event->pt_Right->pt_Left->pt_Right, UINT32_MAX);
-#endif
+#endif /* ITC_CONFIG_USE_64BIT_EVENT_COUNTERS */
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(pt_Stamp->pt_Event->pt_Right->pt_Right, 0);
     /* clang-format on */
 

--- a/libitc/test/normal/ITC_SerDes_Test.c
+++ b/libitc/test/normal/ITC_SerDes_Test.c
@@ -329,7 +329,7 @@ void ITC_SerDes_Test_serialiseToStringIdFailWithCorruptId(void)
 void ITC_SerDes_Test_serialiseIdLeafToStringSuccessful(void)
 {
     ITC_Id_t *pt_Id = NULL;
-    char rc_Buffer[10];
+    char rc_Buffer[2];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
 
     const char *z_ExpectedSeedIdSerialisedData = "1";
@@ -346,7 +346,8 @@ void ITC_SerDes_Test_serialiseIdLeafToStringSuccessful(void)
         ITC_SerDes_serialiseIdToString(pt_Id, &rc_Buffer[0], &u32_BufferSize));
 
     /* Test the serialised data is what is expected */
-    TEST_ASSERT_EQUAL(strlen(z_ExpectedSeedIdSerialisedData) + 1, u32_BufferSize);
+    TEST_ASSERT_EQUAL(
+        strlen(z_ExpectedSeedIdSerialisedData) + 1, u32_BufferSize);
     TEST_ASSERT_EQUAL_STRING_LEN(
         z_ExpectedSeedIdSerialisedData,
         &rc_Buffer[0],
@@ -496,6 +497,10 @@ void ITC_SerDes_Test_serialiseIdParentToStringFailWithInsufficentResources(void)
 
         /* Test the string is NULL terminated and the length was not exceeded */
         TEST_ASSERT_LESS_OR_EQUAL(u32_I - 1, strnlen(&rc_Buffer[0], u32_I));
+        for (uint32_t u32_J = u32_I; u32_J < sizeof(rc_Buffer); u32_J++)
+        {
+            TEST_ASSERT_EQUAL_CHAR(0xAA, rc_Buffer[u32_J]);
+        }
 
         /* Test the partial output is what is expected */
         TEST_ASSERT_EQUAL_STRING_LEN(

--- a/libitc/test/normal/ITC_SerDes_Test.c
+++ b/libitc/test/normal/ITC_SerDes_Test.c
@@ -9,8 +9,13 @@
  *
  */
 #include "ITC_SerDes.h"
-#include "ITC_SerDes_Util_package.h"
 #include "ITC_SerDes_Test.h"
+#include "ITC_config.h"
+
+#if !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API)
+#include "ITC_SerDes_package.h"
+#endif /* !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API) */
+#include "ITC_SerDes_Util_package.h"
 
 #include "ITC_SerDes_Test_package.h"
 #include "ITC_Test_package.h"
@@ -20,7 +25,6 @@
 #include "ITC_Event_package.h"
 
 #include "ITC_Stamp.h"
-#include "ITC_config.h"
 
 #include <stdint.h>
 
@@ -265,7 +269,7 @@ void ITC_SerDes_Test_serialiseIdParentSuccessful(void)
 /* Test serialising a Id to string fails with invalid param */
 void ITC_SerDes_Test_serialiseIdToStringFailInvalidParam(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Dummy = NULL;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -298,13 +302,13 @@ void ITC_SerDes_Test_serialiseIdToStringFailInvalidParam(void)
         ITC_STATUS_INVALID_PARAM);
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an ID to string fails with corrupt ID */
 void ITC_SerDes_Test_serialiseToStringIdFailWithCorruptId(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -330,13 +334,13 @@ void ITC_SerDes_Test_serialiseToStringIdFailWithCorruptId(void)
     }
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a leaf ID to string succeeds */
 void ITC_SerDes_Test_serialiseIdLeafToStringSuccessful(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[2];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -390,13 +394,13 @@ void ITC_SerDes_Test_serialiseIdLeafToStringSuccessful(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an ID to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseIdToStringFailWithInsufficentResources(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[ITC_SER_TO_STR_ID_MIN_BUFFER_LEN];
     uint32_t u32_BufferSize;
@@ -426,13 +430,13 @@ void ITC_SerDes_Test_serialiseIdToStringFailWithInsufficentResources(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a parent ID to string succeeds */
 void ITC_SerDes_Test_serialiseIdParentToStringSuccessful(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[22];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -473,13 +477,13 @@ void ITC_SerDes_Test_serialiseIdParentToStringSuccessful(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a parent ID to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseIdParentToStringFailWithInsufficentResources(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Id_t *pt_Id = NULL;
     char rc_Buffer[21];
     uint32_t u32_BufferSize;
@@ -533,7 +537,7 @@ void ITC_SerDes_Test_serialiseIdParentToStringFailWithInsufficentResources(void)
     TEST_SUCCESS(ITC_Id_destroy(&pt_Id));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test deserialising a ID fails with invalid param */
@@ -941,7 +945,7 @@ void ITC_SerDes_Test_serialiseEventParentSuccessful(void)
 /* Test serialising a Event to string fails with invalid param */
 void ITC_SerDes_Test_serialiseEventToStringFailInvalidParam(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Dummy = NULL;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -974,13 +978,13 @@ void ITC_SerDes_Test_serialiseEventToStringFailInvalidParam(void)
         ITC_STATUS_INVALID_PARAM);
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an Event to string fails with corrupt Event */
 void ITC_SerDes_Test_serialiseToStringEventFailWithCorruptEvent(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event;
     char rc_Buffer[10] = { 0 };
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -1006,13 +1010,13 @@ void ITC_SerDes_Test_serialiseToStringEventFailWithCorruptEvent(void)
     }
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a leaf Event to string succeeds */
 void ITC_SerDes_Test_serialiseEventLeafToStringSuccessful(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
     char rc_Buffer[3];
     uint32_t u32_BufferSize = sizeof(rc_Buffer);
@@ -1072,13 +1076,13 @@ void ITC_SerDes_Test_serialiseEventLeafToStringSuccessful(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising an Event to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseEventToStringFailWithInsufficentResources(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
     char rc_Buffer[ITC_SER_TO_STR_EVENT_MIN_BUFFER_LEN];
     uint32_t u32_BufferSize;
@@ -1108,13 +1112,13 @@ void ITC_SerDes_Test_serialiseEventToStringFailWithInsufficentResources(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a parent Event to string succeeds */
 void ITC_SerDes_Test_serialiseEventParentToStringSuccessful(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     char rc_Buffer[48];
@@ -1165,13 +1169,13 @@ void ITC_SerDes_Test_serialiseEventParentToStringSuccessful(void)
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test serialising a parent Event to string fails with insufficent resources */
 void ITC_SerDes_Test_serialiseEventParentToStringFailWithInsufficentResources(void)
 {
-#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API
+#if ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API
     ITC_Event_t *pt_Event = NULL;
 #if ITC_CONFIG_USE_64BIT_EVENT_COUNTERS
     char rc_Buffer[47];
@@ -1234,7 +1238,7 @@ void ITC_SerDes_Test_serialiseEventParentToStringFailWithInsufficentResources(vo
     TEST_SUCCESS(ITC_Event_destroy(&pt_Event));
 #else
     TEST_IGNORE_MESSAGE("Serialise to string API support is disabled");
-#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API */
+#endif /* ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API */
 }
 
 /* Test deserialising an Event fails with invalid param */

--- a/libitc/test/normal/ITC_Stamp_Test.c
+++ b/libitc/test/normal/ITC_Stamp_Test.c
@@ -1681,7 +1681,7 @@ void ITC_Stamp_Test_setIdOfStampFailWithCorruptId(void)
     /* Destroy the Stamp */
     TEST_SUCCESS(ITC_Stamp_destroy(&pt_Stamp));
 #else
-  TEST_IGNORE_MESSAGE("Extended API support is disabled");
+    TEST_IGNORE_MESSAGE("Extended API support is disabled");
 #endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 


### PR DESCRIPTION
Add the following optional APIs to the public API:

 * `ITC_SerDes_serialiseIdToString`
 * `ITC_SerDes_serialiseEventToString`
 * `ITC_SerDes_serialiseStampToString`